### PR TITLE
Highlight TidalDrift peers and add persistent custom naming

### DIFF
--- a/TidalDrift/App/AppState.swift
+++ b/TidalDrift/App/AppState.swift
@@ -69,7 +69,8 @@ class AppState: ObservableObject {
     
     func refreshLocalInfo() {
         localIPAddress = NetworkUtils.getLocalIPAddress() ?? "Unknown"
-        computerName = NetworkUtils.computerName
+        let custom = settings.tidalDriftDisplayName
+        computerName = custom.isEmpty ? NetworkUtils.computerName : custom
         
         // Defer sharing status check to avoid blocking UI
         Task.detached(priority: .background) { [weak self] in

--- a/TidalDrift/Models/AppSettings.swift
+++ b/TidalDrift/Models/AppSettings.swift
@@ -22,6 +22,9 @@ struct AppSettings: Codable, Equatable {
     // TidalDrop settings
     var tidalDropDestination: String
     
+    // Bonjour display name (persists across IP changes)
+    var tidalDriftDisplayName: String
+    
     init(launchAtLogin: Bool = false,
          scanIntervalSeconds: Int = 30,
          showNotifications: Bool = true,
@@ -37,7 +40,8 @@ struct AppSettings: Codable, Equatable {
          wakeOnLANPort: Int = 9,
          wakeOnLANRetries: Int = 3,
          autoWakeBeforeConnect: Bool = true,
-         tidalDropDestination: String = "") {
+         tidalDropDestination: String = "",
+         tidalDriftDisplayName: String = "") {
         self.launchAtLogin = launchAtLogin
         self.scanIntervalSeconds = scanIntervalSeconds
         self.showNotifications = showNotifications
@@ -54,6 +58,7 @@ struct AppSettings: Codable, Equatable {
         self.wakeOnLANRetries = wakeOnLANRetries
         self.autoWakeBeforeConnect = autoWakeBeforeConnect
         self.tidalDropDestination = tidalDropDestination
+        self.tidalDriftDisplayName = tidalDriftDisplayName
     }
     
     /// Returns the TidalDrop destination folder, defaulting to ~/Public/Drop Box

--- a/TidalDrift/Models/DiscoveredDevice.swift
+++ b/TidalDrift/Models/DiscoveredDevice.swift
@@ -20,6 +20,15 @@ struct DiscoveredDevice: Identifiable, Codable, Hashable {
     var peerMacOSVersion: String?
     var peerUserName: String?
     var peerUptimeHours: Int?
+    var peerTidalDriftName: String?
+    
+    /// Display name: prefer the peer's custom TidalDrift name, fall back to discovered name
+    var displayName: String {
+        if let tdName = peerTidalDriftName, !tdName.isEmpty {
+            return tdName
+        }
+        return name
+    }
     
     /// Stable identifier based on name + IP for credential storage
     var stableId: String {
@@ -42,7 +51,8 @@ struct DiscoveredDevice: Identifiable, Codable, Hashable {
          peerMemoryGB: Int? = nil,
          peerMacOSVersion: String? = nil,
          peerUserName: String? = nil,
-         peerUptimeHours: Int? = nil) {
+         peerUptimeHours: Int? = nil,
+         peerTidalDriftName: String? = nil) {
         self.id = id
         self.name = name
         self.hostname = hostname
@@ -60,6 +70,7 @@ struct DiscoveredDevice: Identifiable, Codable, Hashable {
         self.peerMacOSVersion = peerMacOSVersion
         self.peerUserName = peerUserName
         self.peerUptimeHours = peerUptimeHours
+        self.peerTidalDriftName = peerTidalDriftName
     }
     
     enum ServiceType: String, Codable, CaseIterable {

--- a/TidalDrift/Services/NetworkDiscoveryService.swift
+++ b/TidalDrift/Services/NetworkDiscoveryService.swift
@@ -967,7 +967,10 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
     
     private func updatePublishedDevices() {
         deviceCacheLock.lock()
-        let devices = Array(deviceCache.values).sorted { $0.name < $1.name }
+        let devices = Array(deviceCache.values).sorted { a, b in
+            if a.isTidalDriftPeer != b.isTidalDriftPeer { return a.isTidalDriftPeer }
+            return a.displayName.localizedCaseInsensitiveCompare(b.displayName) == .orderedAscending
+        }
         deviceCacheLock.unlock()
         
         DispatchQueue.main.async {
@@ -1036,6 +1039,7 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
                 device.peerMacOSVersion = peerInfo.macOSVersion
                 device.peerUserName = peerInfo.userName
                 device.peerUptimeHours = peerInfo.uptimeHours
+                device.peerTidalDriftName = peerInfo.tidalDriftName
                 
                 // Keep the most accurate IP
                 if !inputIP.isEmpty && inputIP != "Unknown" {
@@ -1044,7 +1048,7 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
                 
                 self.deviceCache[device.ipAddress] = device
                 self.deviceCacheLock.unlock()
-                print("🌊 TidalDrift PEER: ✅ Updated cache entry '\(device.name)' as peer")
+                print("🌊 TidalDrift PEER: ✅ Updated cache entry '\(device.displayName)' as peer")
             } else {
                 // Create a new device entry for this TidalDrift peer
                 let displayName = hostname.replacingOccurrences(of: ".local", with: "")
@@ -1062,7 +1066,8 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
                     peerMemoryGB: peerInfo.memoryGB,
                     peerMacOSVersion: peerInfo.macOSVersion,
                     peerUserName: peerInfo.userName,
-                    peerUptimeHours: peerInfo.uptimeHours
+                    peerUptimeHours: peerInfo.uptimeHours,
+                    peerTidalDriftName: peerInfo.tidalDriftName
                 )
                 self.deviceCache[newDevice.ipAddress] = newDevice
                 self.deviceCacheLock.unlock()

--- a/TidalDrift/Services/TidalDriftPeerService.swift
+++ b/TidalDrift/Services/TidalDriftPeerService.swift
@@ -58,7 +58,15 @@ class TidalDriftPeerService: NSObject, ObservableObject {
     
     private let serviceType = "_tidaldrift._tcp"
     private let dropServiceType = "_tidaldrop._tcp"
-    private let deviceName = NetworkUtils.sanitizedComputerName
+    
+    /// The advertised name: custom TidalDrift display name if set, otherwise system computer name
+    var advertisedName: String {
+        let custom = AppState.shared.settings.tidalDriftDisplayName
+        if !custom.isEmpty {
+            return custom.replacingOccurrences(of: "'", with: "").replacingOccurrences(of: " ", with: "-")
+        }
+        return NetworkUtils.sanitizedComputerName
+    }
     
     private let localInfo: PeerInfo
     
@@ -75,6 +83,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         let tidalDriftVersion: String
         let screenSharingEnabled: Bool
         let fileSharingEnabled: Bool
+        var tidalDriftName: String?
     }
     
     private override init() {
@@ -141,7 +150,8 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/dns-sd")
         
-        let txtParts = [
+        let customName = AppState.shared.settings.tidalDriftDisplayName
+        var txtParts = [
             "model=\(localInfo.modelName)",
             "modelId=\(localInfo.modelIdentifier)",
             "cpu=\(localInfo.processorInfo)",
@@ -154,8 +164,12 @@ class TidalDriftPeerService: NSObject, ObservableObject {
             "file=\(localInfo.fileSharingEnabled ? "1" : "0")",
             "ip=\(currentIP)"
         ]
+        if !customName.isEmpty {
+            txtParts.append("tdname=\(customName)")
+        }
         
-        var args = ["-R", deviceName, serviceType, "local.", "5959"]
+        let advName = advertisedName
+        var args = ["-R", advName, serviceType, "local.", "5959"]
         args.append(contentsOf: txtParts)
         process.arguments = args
         
@@ -165,7 +179,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         do {
             try process.run()
             dnssdProcess = process
-            Self.log("✅ dns-sd advertising: \(deviceName) on \(serviceType) with \(txtParts.count) TXT fields")
+            Self.log("✅ dns-sd advertising: \(advName) on \(serviceType) with \(txtParts.count) TXT fields")
             DispatchQueue.main.async {
                 self.isAdvertising = true
             }
@@ -200,6 +214,12 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         Self.log("Stopped advertising")
     }
     
+    func restartAdvertising() {
+        stopAdvertising()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.startAdvertising()
+        }
+    }
     
     private func createTXTRecord() -> NWTXTRecord {
         var txt = NWTXTRecord()
@@ -317,7 +337,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
                     if let idx = serviceTypeIndex, idx + 1 < components.count {
                         let instanceName = components[(idx + 1)...].joined(separator: " ")
                         
-                        let isSelf = instanceName == deviceName
+                        let isSelf = instanceName == advertisedName
                         Self.log("🔎 Discovered via dns-sd: '\(instanceName)'\(isSelf ? " (self)" : "")")
                         
                         // Resolve the service to get IP
@@ -564,7 +584,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
             actualIP = localInfo.ipAddress
         }
         
-        let isSelf = name == deviceName
+        let isSelf = name == advertisedName
         
         // Get TXT record if available (thread-safe)
         txtRecordsLock.lock()
@@ -598,7 +618,8 @@ class TidalDriftPeerService: NSObject, ObservableObject {
                 uptimeHours: Int(txt?["uptime"] ?? "0") ?? 0,
                 tidalDriftVersion: version,
                 screenSharingEnabled: txt?["screen"] == "1",
-                fileSharingEnabled: txt?["file"] == "1"
+                fileSharingEnabled: txt?["file"] == "1",
+                tidalDriftName: txt?["tdname"]
             )
         }
         
@@ -627,7 +648,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
     private func processBrowseResults(_ results: Set<NWBrowser.Result>) {
         for result in results {
             if case .service(let name, let type, let domain, _) = result.endpoint {
-                let isSelf = name == deviceName
+                let isSelf = name == advertisedName
                 Self.log("Discovered service: '\(name)'\(isSelf ? " (self)" : "")")
                 
                 // Extract TXT record if available
@@ -716,7 +737,8 @@ class TidalDriftPeerService: NSObject, ObservableObject {
             uptimeHours: Int(txt?["uptime"] ?? "0") ?? 0,
             tidalDriftVersion: txt?["version"] ?? "1.0",
             screenSharingEnabled: txt?["screen"] == "1",
-            fileSharingEnabled: txt?["file"] == "1"
+            fileSharingEnabled: txt?["file"] == "1",
+            tidalDriftName: txt?["tdname"]
         )
         
         DispatchQueue.main.async {
@@ -868,7 +890,7 @@ extension TidalDriftPeerService: NetServiceBrowserDelegate {
         Self.log("🔎 Discovered service: '\(service.name)' type: \(service.type)")
         
         // Note: For single-computer testing, we don't skip ourselves
-        let isSelf = service.name == deviceName
+        let isSelf = service.name == advertisedName
         if isSelf {
             Self.log("(This is our own service)")
         }
@@ -947,7 +969,8 @@ extension TidalDriftPeerService: NetServiceBrowserDelegate {
             uptimeHours: Int(txtValues["uptime"] ?? "0") ?? 0,
             tidalDriftVersion: txtValues["version"] ?? "1.0",
             screenSharingEnabled: txtValues["screen"] == "1",
-            fileSharingEnabled: txtValues["file"] == "1"
+            fileSharingEnabled: txtValues["file"] == "1",
+            tidalDriftName: txtValues["tdname"]
         )
         
         DispatchQueue.main.async {

--- a/TidalDrift/Views/MenuBarView.swift
+++ b/TidalDrift/Views/MenuBarView.swift
@@ -8,9 +8,16 @@ struct MenuBarView: View {
     @State private var isTogglingLocalCast = false
     @State private var showPermissionAlert = false
     @State private var permissionAlertMessage = ""
+    @State private var isEditingName = false
+    @State private var editingNameText = ""
     
     private var otherDevices: [DiscoveredDevice] {
         appState.discoveredDevices.filter { !$0.isCurrentDevice }
+    }
+    
+    private var localDisplayName: String {
+        let custom = appState.settings.tidalDriftDisplayName
+        return custom.isEmpty ? appState.computerName : custom
     }
     
     var body: some View {
@@ -46,9 +53,45 @@ struct MenuBarView: View {
                 .foregroundColor(.accentColor)
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(appState.computerName)
-                    .font(.system(size: 13, weight: .semibold))
-                    .lineLimit(1)
+                if isEditingName {
+                    HStack(spacing: 4) {
+                        TextField("Display name", text: $editingNameText)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12))
+                            .frame(maxWidth: 160)
+                            .onSubmit { commitNameEdit() }
+                        Button(action: { commitNameEdit() }) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                                .font(.system(size: 14))
+                        }
+                        .buttonStyle(.plain)
+                        Button(action: { isEditingName = false }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                                .font(.system(size: 14))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } else {
+                    HStack(spacing: 4) {
+                        Text(localDisplayName)
+                            .font(.system(size: 13, weight: .semibold))
+                            .lineLimit(1)
+                        Button(action: {
+                            editingNameText = appState.settings.tidalDriftDisplayName.isEmpty
+                                ? appState.computerName
+                                : appState.settings.tidalDriftDisplayName
+                            isEditingName = true
+                        }) {
+                            Image(systemName: "pencil")
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Rename this Mac on the TidalDrift network")
+                    }
+                }
                 Text(appState.localIPAddress)
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.secondary)
@@ -62,6 +105,14 @@ struct MenuBarView: View {
                 StatusDot(on: appState.tidalDropListening, label: "Drop")
             }
         }
+    }
+    
+    private func commitNameEdit() {
+        let trimmed = editingNameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isDefault = trimmed.isEmpty || trimmed == appState.computerName
+        appState.settings.tidalDriftDisplayName = isDefault ? "" : trimmed
+        isEditingName = false
+        TidalDriftPeerService.shared.restartAdvertising()
     }
     
     // MARK: - LocalCast
@@ -345,12 +396,13 @@ struct MenuBarDeviceRow: View {
             HStack(spacing: 8) {
                 Image(systemName: device.deviceIcon)
                     .font(.system(size: 11))
-                    .foregroundColor(.accentColor)
+                    .foregroundColor(device.isTidalDriftPeer ? .red : .accentColor)
                     .frame(width: 16)
                 
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(device.name)
+                    Text(device.displayName)
                         .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(device.isTidalDriftPeer ? .red : .primary)
                         .lineLimit(1)
                     Text(device.ipAddress)
                         .font(.system(size: 9, design: .monospaced))


### PR DESCRIPTION
## Summary

- **Peer highlighting**: TidalDrift peers are sorted to the top of the device list and colored red (icon + name) for instant visual distinction
- **Custom naming**: Users can set a persistent TidalDrift display name via an inline edit in the menu bar header; the name is advertised over Bonjour and displayed on remote peers, surviving IP changes
- **Data flow**: Custom name stored in `AppSettings`, advertised as `tdname` TXT record, parsed into `DiscoveredDevice.peerTidalDriftName`, surfaced via `displayName` computed property

Closes #3

## Test plan

- [ ] Verify TidalDrift peers appear at the top of the Nearby Devices list
- [ ] Verify peer names and icons are colored red
- [ ] Click the pencil icon next to the computer name, enter a custom name, confirm
- [ ] Verify the custom name appears on the remote Mac's device list
- [ ] Clear the custom name (set empty) and verify it reverts to system hostname
- [ ] Restart the app and verify the custom name persists