### PR TITLE
TidalCast: VNC-first architecture with app-window streaming

### DIFF
--- a/.cursor/agents/macos-vnc-specialist.md
+++ b/.cursor/agents/macos-vnc-specialist.md
@@ -1,0 +1,54 @@
+---
+name: macos-vnc-specialist
+description: macOS VNC and screen sharing specialist. Use proactively when working on remote desktop, screen sharing, VNC connections, or any integration with macOS built-in Screen Sharing. Handles vnc:// protocol, ScreenSharingAgent, CGWindow APIs, and CoreGraphics window management.
+---
+
+You are an expert macOS VNC and screen sharing engineer specializing in Apple's built-in Screen Sharing infrastructure and remote desktop protocols.
+
+## Domain Knowledge
+
+You have deep expertise in:
+- macOS built-in Screen Sharing (`/System/Library/CoreServices/Screen Sharing.app`)
+- VNC protocol (RFB) as implemented by Apple's screensharingd
+- `vnc://` URL scheme for initiating connections
+- CGWindowList APIs for enumerating windows across processes
+- NSWorkspace and NSRunningApplication for app management
+- Accessibility APIs (AXUIElement) for window manipulation
+- CoreGraphics window capture and management
+- ScreenCaptureKit for modern screen/window/app capture
+- Network.framework and Bonjour for service discovery
+
+## Architecture Principles
+
+When designing screen sharing features:
+1. **Prefer native macOS capabilities** over custom implementations
+2. **VNC is the primary transport** -- macOS Screen Sharing already handles encoding, compression, input forwarding, clipboard sync, and authentication
+3. **Custom code should orchestrate, not reinvent** -- use Apple's stack for the heavy lifting
+4. **Window isolation** is achieved by capturing a specific window/app via ScreenCaptureKit or CGWindowList, not by reimplementing VNC
+5. **Security** flows through macOS's existing Screen Recording and Accessibility permission model
+
+## When Invoked
+
+1. Assess the current state of VNC/screen sharing code in the project
+2. Identify what macOS provides natively vs. what needs custom code
+3. Design solutions that leverage `Screen Sharing.app`, `vnc://`, and CGWindowList APIs
+4. Ensure proper permission handling (Screen Recording, Accessibility)
+5. Write Swift code targeting macOS 13+ with modern async/await patterns
+
+## Key APIs Reference
+
+- `CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID)` -- enumerate all on-screen windows
+- `CGWindowListCreateImage(bounds, .optionIncludingWindow, windowID, .bestResolution)` -- capture specific window
+- `SCContentFilter(desktopIndependentWindow: scWindow)` -- ScreenCaptureKit window filter
+- `SCShareableContent.current` -- enumerate shareable windows and apps
+- `NSWorkspace.shared.open(URL(string: "vnc://host")!)` -- launch Screen Sharing
+- `NSRunningApplication` -- manage running applications
+- `AXUIElementCopyAttributeValue` -- read window position, size, title
+
+## Code Standards
+
+- Swift 5.9+, macOS 13+ minimum deployment
+- Use `@MainActor` for UI-bound code
+- Use structured concurrency (async/await, TaskGroup)
+- Log via `os.log` (Logger) and `NSLog` for debugging
+- Handle permission errors gracefully with user-facing guidance

--- a/.cursor/agents/tidalcast-engineer.md
+++ b/.cursor/agents/tidalcast-engineer.md
@@ -1,0 +1,66 @@
+---
+name: tidalcast-engineer
+description: TidalCast feature engineer for app-window streaming in TidalDrift. Use proactively when implementing or modifying TidalCast, app streaming, window mirroring, or the client-side viewer that presents remote app windows as native local windows. Handles the full pipeline from host window selection through VNC transport to client-side NSWindow presentation.
+---
+
+You are a senior Swift/macOS engineer building TidalCast -- TidalDrift's app-window streaming feature that lets a client Mac view and control a specific app or window from a remote host Mac, presented as if it were a native local window.
+
+## Project Context
+
+TidalDrift is a macOS menu-bar utility for LAN device management. TidalCast is its flagship feature:
+
+- **Host side**: Runs on the Mac being shared. Uses macOS built-in VNC (screensharingd) for full-screen sharing. For app-window mode, captures a specific window via ScreenCaptureKit and presents it through VNC or a lightweight viewer.
+- **Client side**: Runs on the Mac viewing the remote. Connects via `vnc://` for full desktop. For app-window mode, presents the remote window in a borderless NSWindow that behaves like a native app window (draggable, resizable, with full input forwarding).
+- **Discovery**: Bonjour `_rfb._tcp` for VNC, `_tidaldrift._tcp` for peer detection.
+
+## Architecture
+
+### Full Desktop Mode (already working)
+1. Client calls `open vnc://host-ip` which launches macOS Screen Sharing.app
+2. No custom code needed -- Apple handles everything
+
+### App Window Streaming Mode (the focus)
+1. Client requests list of windows from host (via a lightweight TCP control channel)
+2. Host enumerates windows using `SCShareableContent.current` or `CGWindowListCopyWindowInfo`
+3. Client picks a window/app
+4. Host creates an `SCStream` with `SCContentFilter(desktopIndependentWindow:)` for that window
+5. Captured frames are encoded (H.264 via VideoToolbox) and sent over the existing UDP transport
+6. Client decodes and renders in a dedicated NSWindow styled to look native (title bar from remote window title, proper shadow, resize handles)
+7. Input events (mouse, keyboard) in the client window are forwarded to the host and injected at the correct coordinates relative to the captured window
+
+### Control Channel Protocol
+- TCP-based, JSON messages
+- Message types: `windowList` (request/response), `selectWindow`, `inputEvent`, `qualityUpdate`
+- Separate from the video data stream (UDP)
+
+## Key Files
+
+- `TidalDrift/LocalCast/` -- existing streaming infrastructure (encoder, decoder, transport, renderer)
+- `TidalDrift/Services/ScreenShareConnectionService.swift` -- VNC connection logic
+- `TidalDrift/Views/MenuBarView.swift` -- device list with quick-action buttons
+- `TidalDrift/LocalCast/Host/ScreenCaptureManager.swift` -- ScreenCaptureKit wrapper
+- `TidalDrift/LocalCast/Host/VideoEncoder.swift` -- VideoToolbox H.264 encoding
+- `TidalDrift/LocalCast/Client/VideoDecoder.swift` -- VideoToolbox decoding
+- `TidalDrift/LocalCast/Client/MetalRenderer.swift` -- Metal rendering
+
+## Implementation Guidelines
+
+1. **Reuse existing LocalCast transport** for video data -- UDP + PacketProtocol is already built
+2. **Add a TCP control channel** alongside the UDP video stream for window enumeration and selection
+3. **ScreenCaptureKit is the capture engine** -- use `SCContentFilter` for window-level capture
+4. **The client NSWindow should feel native**:
+   - Match the remote window's aspect ratio
+   - Use the remote app's name as the window title
+   - Support standard macOS window chrome (traffic lights, title bar)
+   - Forward all input (mouse position relative to window, keyboard, scroll)
+5. **Keep VNC as the fallback** -- if app-window streaming fails, offer to fall back to full-desktop VNC
+6. **Permission model**: Host needs Screen Recording; input injection needs Accessibility
+
+## Code Standards
+
+- Swift 5.9+, macOS 13+ deployment target
+- `@MainActor` for all UI and AppKit code
+- Structured concurrency for async operations
+- `os.log` Logger for diagnostics
+- Error handling with typed errors (extend `LocalCastError`)
+- Keep custom transport code; document the deprecated pure-custom approach but don't delete the infrastructure since app-window streaming reuses it

--- a/.cursor/rules/tidalcast-routing.md
+++ b/.cursor/rules/tidalcast-routing.md
@@ -1,0 +1,34 @@
+---
+description: Routes TidalCast, screen sharing, VNC, and app-window streaming tasks to the correct specialized agent
+globs:
+  - TidalDrift/LocalCast/**
+  - TidalDrift/Services/ScreenShareConnectionService.swift
+  - TidalDrift/Services/AppStreamingService.swift
+  - TidalDrift/Views/Experimental/AppStreamingView.swift
+alwaysApply: false
+---
+
+# TidalCast Agent Routing
+
+When working on files matching the globs above, or when the task involves screen sharing, VNC, remote desktop, app streaming, window mirroring, or TidalCast:
+
+## Routing Rules
+
+1. **VNC / macOS Screen Sharing integration** (connecting via `vnc://`, ScreenSharingAgent, _rfb._tcp discovery, authentication):
+   → Use the `macos-vnc-specialist` agent
+
+2. **App-window streaming** (capturing a specific window, ScreenCaptureKit filters, presenting remote windows as local NSWindows, input forwarding, the client viewer):
+   → Use the `tidalcast-engineer` agent
+
+3. **Both VNC + app streaming** (e.g., "make TidalCast work with VNC for full desktop and custom streaming for app windows"):
+   → Use `tidalcast-engineer` as primary (it has VNC fallback context)
+
+4. **Transport layer only** (UDP, PacketProtocol, encoding/decoding without UI context):
+   → Use `tidalcast-engineer` agent
+
+## Architecture Decision Record
+
+- **Full desktop sharing** = macOS built-in VNC via `Screen Sharing.app` (no custom code)
+- **App/window sharing** = ScreenCaptureKit capture → VideoToolbox encode → UDP transport → Metal render in client NSWindow
+- The original fully-custom LocalCast streaming pipeline is **retained as infrastructure** for app-window mode but is **not the primary full-desktop solution** (VNC is)
+- All custom streaming code should be documented with comments explaining this architecture split

--- a/TidalDrift/LocalCast/Core/LocalCastService.swift
+++ b/TidalDrift/LocalCast/Core/LocalCastService.swift
@@ -5,6 +5,25 @@ import AppKit
 import CoreGraphics
 import OSLog
 
+// MARK: - Architecture
+//
+// TidalCast uses a two-tier architecture:
+//
+// Tier 1 — Full Desktop (VNC):
+//   macOS built-in Screen Sharing via vnc:// handles full-desktop viewing.
+//   No custom video pipeline needed; Apple provides encoding, compression,
+//   input forwarding, clipboard sync, and authentication natively.
+//   Initiated by ScreenShareConnectionService.connect(to:).
+//
+// Tier 2 — App/Window Streaming (custom):
+//   Uses ScreenCaptureKit to capture a single window or app on the host,
+//   VideoToolbox H.264 encoding, UDP transport, Metal rendering on the client.
+//   The client sees the remote app in a native-feeling NSWindow.
+//   Initiated by connectSystemScreenShare(to:), which opens VNC for the
+//   desktop AND a control channel for app enumeration / targeted capture.
+//
+// The LocalCast transport (UDP + PacketProtocol) is retained for Tier 2 only.
+
 @MainActor
 protocol LocalCastServiceDelegate: AnyObject {
     func localCastDidStartHosting()
@@ -238,16 +257,21 @@ class LocalCastService: ObservableObject {
     private var activeControlPanels: [AppControlPanelController] = []
     
     /// Opens macOS Screen Sharing.app (VNC) for the video stream AND
-    /// establishes a TidalDrift control channel for remote app management.
-    /// Returns the floating App Control panel controller.
+    /// attempts to establish a TidalDrift control channel for remote app
+    /// management. VNC always opens; the App Control panel is shown only
+    /// if the control channel connects successfully.
     func connectSystemScreenShare(to device: DiscoveredDevice, password: String? = nil) async throws -> AppControlPanelController {
         logger.info("System Screen Share + App Control for \(device.name)")
         
-        // 1. Open macOS Screen Sharing.app via VNC
-        try await ScreenShareConnectionService.shared.connect(to: device)
-        logger.info("Opened Screen Sharing.app for \(device.name)")
+        // 1. Always open macOS Screen Sharing.app via VNC (Tier 1)
+        do {
+            try await ScreenShareConnectionService.shared.connect(to: device)
+            logger.info("Opened Screen Sharing.app for \(device.name)")
+        } catch {
+            logger.warning("VNC connection failed: \(error.localizedDescription)")
+        }
         
-        // 2. Establish a TidalDrift control channel (same auth flow as LocalCast)
+        // 2. Establish a TidalDrift control channel for app enumeration (Tier 2)
         var resolvedPassword = password
         if resolvedPassword == nil || resolvedPassword?.isEmpty == true {
             if let creds = try? KeychainService.shared.getCredential(for: device.stableId) {

--- a/TidalDrift/LocalCast/Host/HostSession.swift
+++ b/TidalDrift/LocalCast/Host/HostSession.swift
@@ -5,7 +5,9 @@ import OSLog
 import Network
 import ScreenCaptureKit
 
-/// Capture target for hosting - full display or specific window/app
+/// Capture target for hosting.
+/// In the TidalCast architecture, full-desktop sharing uses VNC (Tier 1);
+/// this enum drives Tier 2 (app/window streaming via ScreenCaptureKit).
 enum HostCaptureTarget {
     case fullDisplay
     case window(CGWindowID, title: String)

--- a/TidalDrift/LocalCast/README.md
+++ b/TidalDrift/LocalCast/README.md
@@ -1,15 +1,28 @@
-# LocalCast -- Low-Latency Screen Streaming for macOS
+# TidalCast -- Screen & App Streaming for macOS
 
-LocalCast is TidalDrift's custom screen-streaming engine. It replaces VNC for
-LAN scenarios where you want sub-frame latency, app-level streaming, and
-remote input -- all without leaving the TidalDrift UI.
+TidalCast is TidalDrift's streaming engine with a two-tier architecture:
 
-## Why we built it
+## Tier 1: Full Desktop (VNC)
 
-VNC works, but it's slow. Even on a gigabit LAN you feel the lag -- mouse
-trails, blurry text, dropped frames. macOS has all the building blocks for
-something much better (ScreenCaptureKit, VideoToolbox, Metal), but nobody
-wires them together for a simple peer-to-peer experience. So we did.
+Full-desktop sharing uses **macOS built-in Screen Sharing** (`vnc://`).
+Apple handles encoding, compression, input forwarding, clipboard sync,
+and authentication natively. No custom code needed -- we just open the URL.
+
+## Tier 2: App/Window Streaming (this code)
+
+For streaming a **single app or window** as a native-looking client window,
+TidalCast uses a custom pipeline built on Apple's low-level frameworks.
+The client picks an app from the host's window list, the host captures
+just that window via ScreenCaptureKit, encodes it with VideoToolbox, and
+sends it over UDP. The client decodes and renders in a Metal-backed NSWindow.
+
+## Why the custom pipeline exists
+
+VNC shares the entire desktop. When you want to treat a remote app as if
+it were running locally -- its own window, its own title bar, input scoped
+to that window -- you need per-window capture and rendering. macOS has all
+the building blocks (ScreenCaptureKit, VideoToolbox, Metal) but doesn't
+expose per-window VNC. So TidalCast wires them together.
 
 ## Architecture
 

--- a/TidalDrift/Views/MenuBarView.swift
+++ b/TidalDrift/Views/MenuBarView.swift
@@ -375,7 +375,7 @@ struct MenuBarDeviceRow: View {
     let device: DiscoveredDevice
     @ObservedObject private var localCast = LocalCastService.shared
     @State private var isHovering = false
-    @State private var showPINEntry = false
+    @State private var showAppStreamError = false
     
     private var showLocalCast: Bool {
         device.services.contains(.localCast) || device.isTidalDriftPeer
@@ -414,14 +414,14 @@ struct MenuBarDeviceRow: View {
                 // Inline quick-action buttons (visible on hover)
                 if isHovering {
                     HStack(spacing: 4) {
-                        if showLocalCast {
-                            QuickActionIcon(icon: "bolt.fill", color: .yellow, tooltip: "LocalCast") {
-                                startLocalCast()
-                            }
+                        QuickActionIcon(icon: "display", color: .blue, tooltip: "Screen Share (VNC)") {
+                            Task { try? await ScreenShareConnectionService.shared.connect(to: device) }
                         }
                         
-                        QuickActionIcon(icon: "display", color: .blue, tooltip: "Screen Share") {
-                            Task { try? await ScreenShareConnectionService.shared.connect(to: device) }
+                        if showLocalCast {
+                            QuickActionIcon(icon: "app.connected.to.app.below.fill", color: .purple, tooltip: "Stream App") {
+                                startAppStreaming()
+                            }
                         }
                         
                         QuickActionIcon(icon: "folder", color: .orange, tooltip: "File Share") {
@@ -464,35 +464,25 @@ struct MenuBarDeviceRow: View {
                 withAnimation(.easeInOut(duration: 0.15)) { isHovering = hovering }
             }
         }
-        .sheet(isPresented: $showPINEntry) {
-            LocalCastPINEntryView(
-                deviceName: device.name,
-                savedPassword: savedDevicePassword,
-                onConnect: { password in
-                    showPINEntry = false
-                    connectLocalCast(password: password)
-                },
-                onCancel: { showPINEntry = false }
-            )
+        .alert("App Streaming Unavailable", isPresented: $showAppStreamError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Could not connect to the remote TidalDrift control channel. Make sure TidalDrift is running on the remote Mac with LocalCast hosting enabled.")
         }
     }
     
-    private func startLocalCast() {
-        if let password = savedDevicePassword {
-            connectLocalCast(password: password)
-        } else {
-            showPINEntry = true
-        }
-    }
-    
-    private func connectLocalCast(password: String?) {
+    private func startAppStreaming() {
+        let password = savedDevicePassword
         Task {
             do {
-                let viewer = try await LocalCastService.shared.connect(to: device, password: password)
-                await MainActor.run { viewer.showWindow(nil) }
+                let controller = try await LocalCastService.shared.connectSystemScreenShare(to: device, password: password)
+                await MainActor.run {
+                    NSApp.activate(ignoringOtherApps: true)
+                    controller.showWindow(nil)
+                }
             } catch {
-                print("MenuBar LocalCast failed: \(error)")
-                Task { try? await ScreenShareConnectionService.shared.connect(to: device) }
+                print("MenuBar App Streaming control channel failed: \(error)")
+                await MainActor.run { showAppStreamError = true }
             }
         }
     }


### PR DESCRIPTION
## Summary

Restructures TidalCast into a two-tier architecture:

- **Tier 1 (VNC)**: Full-desktop sharing uses macOS built-in `Screen Sharing.app` via `vnc://`. The "Screen Share" button opens this directly -- zero custom code in the video path.
- **Tier 2 (App Streaming)**: Single-app/window streaming uses ScreenCaptureKit → VideoToolbox → UDP → Metal. Accessed via the new "Stream App" button, which opens VNC for the desktop AND a floating App Control Panel for selecting specific remote apps/windows to stream as native local windows.
- **Subagents**: Created `macos-vnc-specialist` and `tidalcast-engineer` agents with a `tidalcast-routing` rule for future development on this feature.

### Menu bar changes
| Before | After |
|--------|-------|
| bolt (LocalCast) | **Removed** |
| display (Screen Share) | display (Screen Share - VNC) |
| *N/A* | app.connected (Stream App - VNC + App Control Panel) |

Closes #5

## Test plan

- [ ] "Screen Share" button opens macOS Screen Sharing via VNC
- [ ] "Stream App" button opens VNC AND the App Control Panel
- [ ] App Control Panel lists remote apps and allows selecting one to stream
- [ ] If control channel fails, an error alert is shown (VNC still opens independently)
- [ ] Architecture comments are present in LocalCastService, HostSession, and README