### PR TITLE
Fix flaky UDP/TCP port bind tests with CheckedContinuation

### DIFF
--- a/TidalDrift/Services/TestSuite/NetworkTests.swift
+++ b/TidalDrift/Services/TestSuite/NetworkTests.swift
@@ -4,46 +4,47 @@ import Network
 extension TidalDriftTestRunner {
     
     func testUDPPortBind() async -> (Bool, String) {
-        let testPort: UInt16 = 15904
-        do {
-            let listener = try NWListener(using: .udp, on: NWEndpoint.Port(rawValue: testPort)!)
-            var ready = false
-            listener.stateUpdateHandler = { state in
-                if case .ready = state { ready = true }
-            }
-            listener.start(queue: DispatchQueue(label: "test.udp"))
-            
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            listener.cancel()
-            
-            if ready {
-                return (true, "Successfully bound UDP on port \(testPort)")
-            }
-            return (false, "UDP listener did not reach ready state on port \(testPort)")
-        } catch {
-            return (false, "Cannot bind UDP port \(testPort): \(error.localizedDescription)")
-        }
+        await testPortBind(label: "UDP", params: .udp, port: 15904)
     }
     
     func testTCPPortBind() async -> (Bool, String) {
-        let testPort: UInt16 = 15902
+        await testPortBind(label: "TCP", params: .tcp, port: 15902)
+    }
+    
+    private func testPortBind(label: String, params: NWParameters, port: UInt16) async -> (Bool, String) {
         do {
-            let listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: testPort)!)
-            var ready = false
-            listener.stateUpdateHandler = { state in
-                if case .ready = state { ready = true }
-            }
-            listener.start(queue: DispatchQueue(label: "test.tcp"))
+            let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
             
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            let result = await withCheckedContinuation { (continuation: CheckedContinuation<NWListener.State, Never>) in
+                var resumed = false
+                listener.stateUpdateHandler = { state in
+                    guard !resumed else { return }
+                    switch state {
+                    case .ready, .failed, .cancelled:
+                        resumed = true
+                        continuation.resume(returning: state)
+                    default:
+                        break
+                    }
+                }
+                listener.start(queue: DispatchQueue(label: "test.\(label.lowercased()).bind"))
+                
+                // Timeout after 5 seconds
+                DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+                    guard !resumed else { return }
+                    resumed = true
+                    continuation.resume(returning: .cancelled)
+                }
+            }
+            
             listener.cancel()
             
-            if ready {
-                return (true, "Successfully bound TCP on port \(testPort)")
+            if case .ready = result {
+                return (true, "Successfully bound \(label) on port \(port)")
             }
-            return (false, "TCP listener did not reach ready state on port \(testPort)")
+            return (false, "\(label) listener reached state \(result) instead of ready on port \(port)")
         } catch {
-            return (false, "Cannot bind TCP port \(testPort): \(error.localizedDescription)")
+            return (false, "Cannot bind \(label) port \(port): \(error.localizedDescription)")
         }
     }
     

--- a/TidalDrift/Services/TestSuite/TidalDriftTestRunner.swift
+++ b/TidalDrift/Services/TestSuite/TidalDriftTestRunner.swift
@@ -116,8 +116,8 @@ class TidalDriftTestRunner: ObservableObject {
         allTests.append(("TidalDrop Listener Active", "Bonjour", testTidalDropListener))
         
         // Network
-        allTests.append(("UDP Port 5904 Bind", "Network", testUDPPortBind))
-        allTests.append(("TCP Port 5902 Bind", "Network", testTCPPortBind))
+        allTests.append(("UDP Port Bind", "Network", testUDPPortBind))
+        allTests.append(("TCP Port Bind", "Network", testTCPPortBind))
         allTests.append(("Loopback TCP Roundtrip", "Network", testLoopbackTCPRoundtrip))
         allTests.append(("Loopback UDP Roundtrip", "Network", testLoopbackUDPRoundtrip))
         


### PR DESCRIPTION
## Summary

- Replace data-racy sleep+flag pattern with `CheckedContinuation` in port bind tests
- Extend timeout from 1s to 5s to handle Local Network permission delays
- Correct misleading test names ("UDP Port 5904" → "UDP Port Bind")

Closes #9

## Test plan

- [ ] Run integration test suite — UDP Port Bind and TCP Port Bind should pass consistently