### PR TITLE
Fix remaining audit findings: resource cleanup, perf, thread safety

### DIFF
--- a/TidalDrift/LocalCast/Client/ClientSession.swift
+++ b/TidalDrift/LocalCast/Client/ClientSession.swift
@@ -171,6 +171,8 @@ class ClientSession: ObservableObject, UDPTransportDelegate, VideoDecoderDelegat
     }
     
     /// Monitor connection progress and provide diagnostics.
+    private static let maxDiagnosticDuration: TimeInterval = 60
+    
     @MainActor
     private func startDiagnosticTimer() {
         diagnosticTimer?.invalidate()
@@ -179,26 +181,23 @@ class ClientSession: ObservableObject, UDPTransportDelegate, VideoDecoderDelegat
             guard let startTime = self.connectionStartTime else { return }
             let elapsed = Date().timeIntervalSince(startTime)
             
-            // Already streaming — nothing to diagnose
-            if self.isConnected { 
+            if self.isConnected || elapsed > Self.maxDiagnosticDuration {
                 self.diagnosticTimer?.invalidate()
+                self.diagnosticTimer = nil
                 return
             }
             
             if self.heartbeatsReceived == 0 {
-                // No heartbeat responses at all
                 if elapsed > 6.0 {
                     self.connectionPhase = .firewallBlocked
                     self.connectionStatus = ConnectionPhase.firewallBlocked.rawValue
                     self.logger.warning("⚠️ No heartbeat responses after \(Int(elapsed))s — likely firewall issue on host")
                 }
-            } else if !self.isConnected {
-                // Heartbeats work but no video
+            } else {
                 if elapsed > 10.0 {
                     self.connectionPhase = .videoTimeout
                     self.connectionStatus = ConnectionPhase.videoTimeout.rawValue
                     self.logger.warning("⚠️ Heartbeats OK but no video after \(Int(elapsed))s")
-                    // Request another keyframe
                     self.requestKeyFrame()
                 }
             }

--- a/TidalDrift/LocalCast/Client/MetalRenderer.swift
+++ b/TidalDrift/LocalCast/Client/MetalRenderer.swift
@@ -25,6 +25,12 @@ class MetalRenderer: NSObject, MTKViewDelegate {
     // Track last drawable size so we recalculate vertices when it changes
     private var lastDrawableSize: CGSize = .zero
     
+    deinit {
+        if let cache = textureCache {
+            CVMetalTextureCacheFlush(cache, 0)
+        }
+    }
+    
     init(mtkView: MTKView) {
         self.mtkView = mtkView
         self.device = mtkView.device ?? MTLCreateSystemDefaultDevice()!

--- a/TidalDrift/LocalCast/Transport/UDPTransport.swift
+++ b/TidalDrift/LocalCast/Transport/UDPTransport.swift
@@ -53,7 +53,14 @@ class UDPTransport {
     
     /// When set, all outgoing packets are encrypted and incoming packets are decrypted.
     /// Auth handshake packets travel in plaintext (prefix 0x00) before this is set.
-    var sessionKey: SymmetricKey?
+    /// Protected by `sessionKeyLock`.
+    private var _sessionKey: SymmetricKey?
+    private let sessionKeyLock = NSLock()
+    
+    var sessionKey: SymmetricKey? {
+        get { sessionKeyLock.lock(); defer { sessionKeyLock.unlock() }; return _sessionKey }
+        set { sessionKeyLock.lock(); _sessionKey = newValue; sessionKeyLock.unlock() }
+    }
     
     private var listener: NWListener?
     private var connections: [String: NWConnection] = [:] // Key by endpoint description for reliable lookup
@@ -69,6 +76,7 @@ class UDPTransport {
     private var fragmentBuffers: [UInt32: [UInt16: Data]] = [:] // frameId -> [fragmentIndex -> data]
     private var fragmentCounts: [UInt32: UInt16] = [:] // frameId -> totalFragments
     private let fragmentLock = NSLock()
+    private var oldestBufferedFrameId: UInt32 = 0
     
     // Safety limits for fragment reassembly
     // Quality-focused encoding at 4K can produce keyframes of 2-5 MB.
@@ -397,13 +405,14 @@ class UDPTransport {
             fragmentBuffers[header.frameId] = [:]
             fragmentCounts[header.frameId] = header.totalFragments
             
-            // Evict stale frames aggressively -- keep only the most recent N
+            if oldestBufferedFrameId == 0 { oldestBufferedFrameId = header.frameId }
+            
             while fragmentBuffers.count > maxBufferedFrames {
-                if let oldestFrame = fragmentBuffers.keys.min() {
-                    fragmentBuffers.removeValue(forKey: oldestFrame)
-                    fragmentCounts.removeValue(forKey: oldestFrame)
-                } else {
-                    break
+                fragmentBuffers.removeValue(forKey: oldestBufferedFrameId)
+                fragmentCounts.removeValue(forKey: oldestBufferedFrameId)
+                oldestBufferedFrameId += 1
+                while !fragmentBuffers.isEmpty && fragmentBuffers[oldestBufferedFrameId] == nil {
+                    oldestBufferedFrameId += 1
                 }
             }
         }

--- a/TidalDrift/Models/DiscoveredDevice.swift
+++ b/TidalDrift/Models/DiscoveredDevice.swift
@@ -107,9 +107,17 @@ struct DiscoveredDevice: Identifiable, Codable, Hashable {
         }
     }
     
-    var isOnline: Bool {
-        Date().timeIntervalSince(lastSeen) < 60
-    }
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+    
+    /// Seconds since this device was last seen. Use this to avoid
+    /// creating multiple Date() objects across the status properties.
+    private var age: TimeInterval { Date().timeIntervalSince(lastSeen) }
+    
+    var isOnline: Bool { age < 60 }
     
     /// Check if this device is the current Mac (by IP address)
     var isCurrentDevice: Bool {
@@ -118,39 +126,29 @@ struct DiscoveredDevice: Identifiable, Codable, Hashable {
     }
     
     /// Device hasn't been seen in 24+ hours
-    var isStale: Bool {
-        Date().timeIntervalSince(lastSeen) > 24 * 60 * 60
-    }
+    var isStale: Bool { age > 24 * 60 * 60 }
     
     /// Device was seen in this session (within the last 5 minutes)
-    var isRecentlyConfirmed: Bool {
-        Date().timeIntervalSince(lastSeen) < 5 * 60
-    }
+    var isRecentlyConfirmed: Bool { age < 5 * 60 }
     
     var statusText: String {
         if isOnline {
             return "Online"
         } else {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .abbreviated
-            return "Last seen \(formatter.localizedString(for: lastSeen, relativeTo: Date()))"
+            return "Last seen \(Self.relativeFormatter.localizedString(for: lastSeen, relativeTo: Date()))"
         }
     }
     
     var lastSeenText: String {
-        let interval = Date().timeIntervalSince(lastSeen)
-        
+        let interval = age
         if interval < 60 {
             return "Just now"
-        } else if interval < 60 * 60 {
-            let mins = Int(interval / 60)
-            return "\(mins)m ago"
-        } else if interval < 24 * 60 * 60 {
-            let hours = Int(interval / 3600)
-            return "\(hours)h ago"
+        } else if interval < 3600 {
+            return "\(Int(interval / 60))m ago"
+        } else if interval < 86400 {
+            return "\(Int(interval / 3600))h ago"
         } else {
-            let days = Int(interval / 86400)
-            return "\(days)d ago"
+            return "\(Int(interval / 86400))d ago"
         }
     }
     

--- a/TidalDrift/Services/NetworkDiscoveryService.swift
+++ b/TidalDrift/Services/NetworkDiscoveryService.swift
@@ -19,6 +19,8 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
     private var pathMonitor: NWPathMonitor?
     private let queue = DispatchQueue(label: "com.tidaldrift.discovery", qos: .userInitiated)
     
+    private var publishDebounceWorkItem: DispatchWorkItem?
+    
     // Store active connections to prevent premature deallocation
     private var activeConnections: [UUID: NWConnection] = [:]
     private let connectionsLock = NSLock()
@@ -405,6 +407,12 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
         netServiceBrowser?.stop()
         netServiceBrowser = nil
         discoveredLocalCastServices.removeAll()
+        
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        
+        udpListener?.cancel()
+        udpListener = nil
     }
     
     func refreshScan() {
@@ -969,19 +977,25 @@ class NetworkDiscoveryService: NSObject, ObservableObject, NetServiceBrowserDele
         }
     }
     
+    /// Coalesces rapid device-cache mutations into a single sort + publish + save.
     private func updatePublishedDevices() {
-        deviceCacheLock.lock()
-        let devices = Array(deviceCache.values).sorted { a, b in
-            if a.isTidalDriftPeer != b.isTidalDriftPeer { return a.isTidalDriftPeer }
-            return a.displayName.localizedCaseInsensitiveCompare(b.displayName) == .orderedAscending
+        publishDebounceWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.deviceCacheLock.lock()
+            let devices = Array(self.deviceCache.values).sorted { a, b in
+                if a.isTidalDriftPeer != b.isTidalDriftPeer { return a.isTidalDriftPeer }
+                return a.displayName.localizedCaseInsensitiveCompare(b.displayName) == .orderedAscending
+            }
+            self.deviceCacheLock.unlock()
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.discoveredDevices = devices
+                self?.saveDevices()
+            }
         }
-        deviceCacheLock.unlock()
-        
-        DispatchQueue.main.async {
-            self.discoveredDevices = devices
-            // Auto-save when devices change
-            self.saveDevices()
-        }
+        publishDebounceWorkItem = work
+        queue.asyncAfter(deadline: .now() + 0.2, execute: work)
     }
     
     func addManualDevice(name: String, ipAddress: String, port: Int = 5900, services: Set<DiscoveredDevice.ServiceType> = [.screenSharing]) {

--- a/TidalDrift/Services/SharingConfigurationService.swift
+++ b/TidalDrift/Services/SharingConfigurationService.swift
@@ -23,6 +23,37 @@ class SharingConfigurationService: ObservableObject, @unchecked Sendable {
         }
     }
     
+    /// Run a Process without blocking the Swift concurrency thread pool.
+    /// Uses `terminationHandler` instead of `waitUntilExit()`.
+    private func runProcess(_ executablePath: String, arguments: [String]) async -> (output: String, exitCode: Int32) {
+        await withCheckedContinuation { continuation in
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: executablePath)
+            task.arguments = arguments
+            
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = pipe
+            
+            let resumed = AtomicFlag(false)
+            task.terminationHandler = { process in
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                if resumed.compareAndSwap(expected: false, desired: true) {
+                    continuation.resume(returning: (output, process.terminationStatus))
+                }
+            }
+            
+            do {
+                try task.run()
+            } catch {
+                if resumed.compareAndSwap(expected: false, desired: true) {
+                    continuation.resume(returning: ("", -1))
+                }
+            }
+        }
+    }
+    
     @MainActor
     func refreshStatus() async {
         screenSharingEnabled = await isScreenSharingEnabled()
@@ -31,30 +62,8 @@ class SharingConfigurationService: ObservableObject, @unchecked Sendable {
     }
     
     func isScreenSharingEnabled() async -> Bool {
-        // Try multiple methods to detect screen sharing status
-        
-        // Method 1: Check if screensharing service is loaded via launchctl print
-        let method1 = await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            task.arguments = ["print", "system/com.apple.screensharing"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = pipe
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                continuation.resume(returning: task.terminationStatus == 0)
-            } catch {
-                continuation.resume(returning: false)
-            }
-        }
-        
-        if method1 { return true }
-        
-        // Method 2: Fast port check using NWConnection (much faster than system_profiler/lsof)
+        let result = await runProcess("/bin/launchctl", arguments: ["print", "system/com.apple.screensharing"])
+        if result.exitCode == 0 { return true }
         return await checkLocalPort(5900)
     }
     
@@ -119,30 +128,8 @@ class SharingConfigurationService: ObservableObject, @unchecked Sendable {
     }
     
     func isFileSharingEnabled() async -> Bool {
-        // Try multiple methods to detect file sharing status
-        
-        // Method 1: Check if smbd service is loaded
-        let method1 = await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            task.arguments = ["print", "system/com.apple.smbd"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = pipe
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                continuation.resume(returning: task.terminationStatus == 0)
-            } catch {
-                continuation.resume(returning: false)
-            }
-        }
-        
-        if method1 { return true }
-        
-        // Method 2: Fast port check using NWConnection (much faster than lsof)
+        let result = await runProcess("/bin/launchctl", arguments: ["print", "system/com.apple.smbd"])
+        if result.exitCode == 0 { return true }
         return await checkLocalPort(445)
     }
     
@@ -157,78 +144,20 @@ class SharingConfigurationService: ObservableObject, @unchecked Sendable {
             return true
         }
         
-        // Method 2: Check via launchctl list as fallback
-        let launchctlCheck = await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            task.arguments = ["list"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                let found = output.contains("com.openssh.sshd")
-                logger.info("launchctl list check: \(found ? "FOUND com.openssh.sshd" : "NOT FOUND")")
-                continuation.resume(returning: found)
-            } catch {
-                logger.error("launchctl list check: ERROR - \(error)")
-                continuation.resume(returning: false)
-            }
-        }
-        
+        let result = await runProcess("/bin/launchctl", arguments: ["list"])
+        let launchctlCheck = result.output.contains("com.openssh.sshd")
         logger.info("Result: SSH \(launchctlCheck ? "ENABLED" : "DISABLED") (launchctl fallback)")
         return launchctlCheck
     }
     
     func isFirewallEnabled() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/libexec/ApplicationFirewall/socketfilterfw")
-            task.arguments = ["--getglobalstate"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = Pipe()
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                // Output is "Firewall is enabled. (State = 1)" or "Firewall is disabled. (State = 0)"
-                continuation.resume(returning: output.lowercased().contains("enabled"))
-            } catch {
-                continuation.resume(returning: false)
-            }
-        }
+        let result = await runProcess("/usr/libexec/ApplicationFirewall/socketfilterfw", arguments: ["--getglobalstate"])
+        return result.output.lowercased().contains("enabled")
     }
     
     func isFirewallBlockingAll() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/libexec/ApplicationFirewall/socketfilterfw")
-            task.arguments = ["--getblockall"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = Pipe()
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                continuation.resume(returning: output.lowercased().contains("enabled"))
-            } catch {
-                continuation.resume(returning: false)
-            }
-        }
+        let result = await runProcess("/usr/libexec/ApplicationFirewall/socketfilterfw", arguments: ["--getblockall"])
+        return result.output.lowercased().contains("enabled")
     }
     
     // MARK: - Toggle Sharing Services
@@ -365,42 +294,15 @@ class SharingConfigurationService: ObservableObject, @unchecked Sendable {
     }
     
     private func runAppleScript(_ source: String) async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            task.arguments = ["-e", source]
-            
-            // Capture output for debugging
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            task.standardOutput = stdoutPipe
-            task.standardError = stderrPipe
-            
-            logger.info("Running AppleScript: \(source.prefix(150))...")
-            
-            do {
-                try task.run()
-                task.waitUntilExit()
-                
-                let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-                
-                logger.info("osascript exit code: \(task.terminationStatus)")
-                if !stdout.isEmpty {
-                    logger.info("osascript stdout: \(stdout, privacy: .public)")
-                }
-                if !stderr.isEmpty {
-                    logger.error("osascript stderr: \(stderr, privacy: .public)")
-                }
-                
-                continuation.resume(returning: task.terminationStatus == 0)
-            } catch {
-                logger.error("Failed to run osascript: \(error)")
-                continuation.resume(returning: false)
-            }
+        logger.info("Running AppleScript: \(source.prefix(150))...")
+        let result = await runProcess("/usr/bin/osascript", arguments: ["-e", source])
+        
+        logger.info("osascript exit code: \(result.exitCode)")
+        if !result.output.isEmpty {
+            logger.info("osascript output: \(result.output, privacy: .public)")
         }
+        
+        return result.exitCode == 0
     }
     
     /// Public method to execute arbitrary AppleScript (for user creation, etc.)

--- a/TidalDrift/Services/StreamingNetworkService.swift
+++ b/TidalDrift/Services/StreamingNetworkService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Network
 import Combine
+import OSLog
 
 /// Represents a remote app available for streaming from another machine
 struct RemoteStreamableApp: Identifiable, Hashable, Codable {
@@ -42,6 +43,7 @@ struct StreamingHost: Identifiable, Hashable {
 @MainActor
 class StreamingNetworkService: ObservableObject, @unchecked Sendable {
     static let shared = StreamingNetworkService()
+    private let logger = Logger(subsystem: "com.tidaldrift", category: "Streaming")
     
     // Bonjour service type for TidalDrift streaming
     private let serviceType = "_tidalstream._tcp"
@@ -69,24 +71,8 @@ class StreamingNetworkService: ObservableObject, @unchecked Sendable {
     
     private init() {}
     
-    // Debug logging to file
     nonisolated private func log(_ message: String) {
-        let logMessage = "[\(Date())] \(message)\n"
-        print(logMessage)
-        
-        // Also write to file for debugging
-        let logPath = "/tmp/tidaldrift_share.log"
-        if let data = logMessage.data(using: .utf8) {
-            if FileManager.default.fileExists(atPath: logPath) {
-                if let handle = FileHandle(forWritingAtPath: logPath) {
-                    handle.seekToEndOfFile()
-                    handle.write(data)
-                    handle.closeFile()
-                }
-            } else {
-                FileManager.default.createFile(atPath: logPath, contents: data)
-            }
-        }
+        logger.debug("\(message, privacy: .public)")
     }
     
     // MARK: - Hosting (Advertising your apps)
@@ -205,23 +191,18 @@ class StreamingNetworkService: ObservableObject, @unchecked Sendable {
     }
     
     nonisolated private func handleIncomingConnection(_ connection: NWConnection) {
-        connection.stateUpdateHandler = { [weak self] state in
+        connection.stateUpdateHandler = { [weak self, weak connection] state in
+            guard let connection = connection else { return }
             switch state {
             case .ready:
-                #if DEBUG
-                print("🎬 Incoming streaming connection ready")
-                #endif
-                // Handle requests for app info or streaming
                 self?.receiveData(on: connection)
             case .failed(let error):
-                #if DEBUG
-                print("🎬 Connection failed: \(error)")
-                #endif
+                self?.logger.warning("Incoming connection failed: \(error.localizedDescription)")
             default:
                 break
             }
         }
-        connection.start(queue: DispatchQueue(label: "com.tidaldrift.connection"))
+        connection.start(queue: queue)
     }
     
     nonisolated private func receiveData(on connection: NWConnection) {
@@ -373,16 +354,15 @@ class StreamingNetworkService: ObservableObject, @unchecked Sendable {
     private func resolveAndConnect(result: NWBrowser.Result, serviceName: String) {
         let connection = NWConnection(to: result.endpoint, using: .tcp)
         
-        connection.stateUpdateHandler = { [weak self] state in
+        connection.stateUpdateHandler = { [weak self, weak connection] state in
+            guard let connection = connection else { return }
             switch state {
             case .ready:
-                // Get the resolved IP address
                 if let endpoint = connection.currentPath?.remoteEndpoint,
                    case .hostPort(let host, let port) = endpoint {
                     let ipAddress = self?.extractIP(from: host) ?? "unknown"
                     
                     Task { @MainActor in
-                        // Parse TXT record for app info
                         if case .bonjour(let txtRecord) = result.metadata {
                             self?.processDiscoveredHost(
                                 name: serviceName,
@@ -394,11 +374,9 @@ class StreamingNetworkService: ObservableObject, @unchecked Sendable {
                     }
                 }
                 
-                // Request app list
                 let request = "LIST_APPS".data(using: .utf8)!
                 connection.send(content: request, completion: .contentProcessed { _ in })
                 
-                // Receive response
                 connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
                     if let data = data {
                         Task { @MainActor in
@@ -408,9 +386,7 @@ class StreamingNetworkService: ObservableObject, @unchecked Sendable {
                 }
                 
             case .failed(let error):
-                #if DEBUG
-                print("🔍 Failed to connect to \(serviceName): \(error)")
-                #endif
+                self?.logger.warning("Failed to connect to \(serviceName): \(error.localizedDescription)")
             default:
                 break
             }

--- a/TidalDrift/Services/TidalDriftPeerService.swift
+++ b/TidalDrift/Services/TidalDriftPeerService.swift
@@ -43,6 +43,9 @@ class TidalDriftPeerService: NSObject, ObservableObject {
     @Published var discoveredPeers: [String: PeerInfo] = [:] // keyed by IP
     @Published var isAdvertising = false
     
+    /// Tracks when each peer IP was last seen for stale-peer pruning.
+    private var peerLastSeen: [String: Date] = [:]
+    
     private var listener: NWListener?
     private var browser: NWBrowser?
     private let queue = DispatchQueue(label: "com.tidaldrift.peer.network", qos: .userInitiated)
@@ -53,8 +56,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
     private var netServiceBrowser: NetServiceBrowser?
     
     private var telemetryTimer: Timer?
-    // UDP heartbeat disabled - requires special permissions
-    // private var udpHeartbeatTimer: Timer?
+    private var peerPruneTimer: Timer?
     
     private let serviceType = "_tidaldrift._tcp"
     private let dropServiceType = "_tidaldrop._tcp"
@@ -293,6 +295,18 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         } catch {
             Self.log("❌ Failed to start dns-sd browse: \(error)")
         }
+        
+        if peerPruneTimer == nil {
+            DispatchQueue.main.async { [weak self] in
+                self?.peerPruneTimer = Timer.scheduledTimer(
+                    timeInterval: 60,
+                    target: self as Any,
+                    selector: #selector(self?.pruneStaleDiscoveredPeers),
+                    userInfo: nil,
+                    repeats: true
+                )
+            }
+        }
     }
     
     func stopDiscovery() {
@@ -311,7 +325,27 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         browseProcess = nil
         browseOutputPipe = nil
         
+        peerPruneTimer?.invalidate()
+        peerPruneTimer = nil
+        
         Self.log("Stopped discovery")
+    }
+    
+    /// Remove peers not refreshed in the last 5 minutes.
+    @objc private func pruneStaleDiscoveredPeers() {
+        let staleThreshold: TimeInterval = 5 * 60
+        let now = Date()
+        var pruned = 0
+        
+        for (ip, lastSeen) in peerLastSeen where now.timeIntervalSince(lastSeen) > staleThreshold {
+            discoveredPeers.removeValue(forKey: ip)
+            peerLastSeen.removeValue(forKey: ip)
+            pruned += 1
+        }
+        
+        if pruned > 0 {
+            Self.log("Pruned \(pruned) stale peer(s) from discoveredPeers")
+        }
     }
     
     private func parseBrowseOutput(_ output: String) {
@@ -633,9 +667,9 @@ class TidalDriftPeerService: NSObject, ObservableObject {
             // (even for self - this ensures the red outline shows)
             self.notifyNetworkDiscovery(peer: peer)
             
-            // Only add to discoveredPeers list if not self
             if !isSelf {
                 self.discoveredPeers[actualIP] = peer
+                self.peerLastSeen[actualIP] = Date()
             }
             
             // Clean up TXT record cache (thread-safe)
@@ -748,6 +782,7 @@ class TidalDriftPeerService: NSObject, ObservableObject {
         
         DispatchQueue.main.async {
             self.discoveredPeers[ip] = peer
+            self.peerLastSeen[ip] = Date()
             self.notifyNetworkDiscovery(peer: peer)
             Self.log("✅ Updated peer '\(name)' at \(ip)")
         }
@@ -980,6 +1015,7 @@ extension TidalDriftPeerService: NetServiceBrowserDelegate {
         
         DispatchQueue.main.async {
             self.discoveredPeers[ipAddress] = peer
+            self.peerLastSeen[ipAddress] = Date()
             self.notifyNetworkDiscovery(peer: peer)
         }
     }

--- a/TidalDrift/Services/TidalDropService.swift
+++ b/TidalDrift/Services/TidalDropService.swift
@@ -44,6 +44,7 @@ class TidalDropService: ObservableObject {
     
     // Store active connections to prevent premature deallocation
     private var activeConnections: [UUID: NWConnection] = [:]
+    private var incomingConnections: [UUID: NWConnection] = [:]
     private let connectionsLock = NSLock()
     
     private init() {
@@ -436,7 +437,28 @@ class TidalDropService: ObservableObject {
         }
     }
     
+    func stopListening() {
+        listener?.cancel()
+        listener = nil
+        
+        connectionsLock.lock()
+        activeConnections.values.forEach { $0.cancel() }
+        activeConnections.removeAll()
+        incomingConnections.values.forEach { $0.cancel() }
+        incomingConnections.removeAll()
+        connectionsLock.unlock()
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.isListening = false
+        }
+    }
+    
     private func handleIncomingConnection(_ connection: NWConnection) {
+        let connID = UUID()
+        connectionsLock.lock()
+        incomingConnections[connID] = connection
+        connectionsLock.unlock()
+        
         print("🌊 TidalDrop: Handling incoming connection from \(connection.endpoint)")
         
         // Extract remote IP for matching in UI
@@ -452,8 +474,17 @@ class TidalDropService: ObservableObject {
             remoteIP = "\(connection.endpoint)"
         }
         
-        connection.stateUpdateHandler = { state in
+        connection.stateUpdateHandler = { [weak self] state in
             print("🌊 TidalDrop: Incoming connection state: \(state)")
+            if case .cancelled = state {
+                self?.connectionsLock.lock()
+                self?.incomingConnections.removeValue(forKey: connID)
+                self?.connectionsLock.unlock()
+            } else if case .failed = state {
+                self?.connectionsLock.lock()
+                self?.incomingConnections.removeValue(forKey: connID)
+                self?.connectionsLock.unlock()
+            }
         }
         
         connection.start(queue: queue)


### PR DESCRIPTION
Closes #13

## Summary

- **Resource cleanup**: Cancel NWPathMonitor + UDP listener on stop; track and cleanup incoming TidalDrop connections; prune stale TidalDrift peers every 60s; flush GPU texture cache in MetalRenderer deinit; cap diagnostic timer at 60s
- **Performance**: Cache static RelativeDateTimeFormatter in DiscoveredDevice; O(1) fragment eviction in UDPTransport via tracked oldest frame ID; debounce device-list publish by 200ms
- **Thread safety**: Protect UDPTransport sessionKey with NSLock; break NWConnection retain cycles in StreamingNetworkService with weak captures; reuse shared queue
- **Logging/Security**: Replace world-readable /tmp log with os.Logger in StreamingNetworkService; replace all 5 Process.waitUntilExit() calls with terminationHandler in SharingConfigurationService

## Test plan

- [ ] Build succeeds with zero warnings
- [ ] Run integration test suite — all pass
- [ ] Verify device discovery still works (debounce doesn't suppress results)
- [ ] Connect to LocalCast host, verify streaming works
- [ ] Check Console.app for `com.tidaldrift` streaming logs (replaces /tmp file)
- [ ] Verify `/tmp/tidaldrift_share.log` is no longer created
- [ ] Confirm System Settings detection (screen sharing, SSH, file sharing) still works
- [ ] Leave app running 10+ min, verify peer list doesn't grow unboundedly