### PR TITLE
docs: update READMEs for open-source release, flag LocalCast status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to TidalDrift
 
-Thanks for your interest in contributing to TidalDrift. Here's how to get started.
+Thank you for your interest in contributing to TidalDrift. This document covers the setup, workflow, and conventions for the project.
 
 ## Getting Started
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/TidalDrift.git`
-3. Make sure Xcode is selected: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+3. Ensure Xcode is selected: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
 4. Build and run: `cd TidalDrift && ./build-app.sh`
 
 ## Development Workflow
@@ -15,21 +15,22 @@ Thanks for your interest in contributing to TidalDrift. Here's how to get starte
 - Make your changes
 - Run the in-app test suite: **Settings > Tests > Run All Tests**
 - Verify the build completes: `cd TidalDrift && ./build-app.sh`
-- Submit a pull request
+- Submit a pull request targeting `main`
 
 ## Code Style
 
 - Follow existing Swift conventions in the codebase
-- Use `Logger` (os.log) for structured logging, not `print` in production paths
-- Avoid adding third-party dependencies -- TidalDrift is built entirely with Apple frameworks
+- Use `Logger` (os.log) for structured logging; do not use `print` in production paths
+- Avoid adding third-party dependencies. TidalDrift is built entirely with Apple frameworks.
 - Keep views composable and small; extract reusable components
 
 ## Areas for Contribution
 
+- **LocalCast app-window streaming**: the custom streaming pipeline is architecturally complete but not yet fully implemented. See [TidalDrift/LocalCast/README.md](TidalDrift/LocalCast/README.md) for the current state.
 - **Linux/cross-platform support** for the networking layer
 - **Improved codec support** (AV1, VP9)
 - **Audio streaming** over LocalCast
-- **Better error recovery** in the UDP transport layer
+- **Error recovery** in the UDP transport layer
 - **Accessibility** improvements
 - **Localization** to other languages
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # TidalDrift
 
-A menu-bar Mac utility for discovering, connecting to, and streaming between Macs on your local network. Built entirely with Apple frameworks -- no external dependencies.
+A menu-bar Mac utility for discovering, connecting to, and streaming between Macs on your local network. Built entirely with Apple frameworks; no external dependencies.
 
-TidalDrift replaces the clunky workflow of opening System Settings, toggling sharing services, remembering IP addresses, and launching Screen Sharing.app. It lives in your menu bar, discovers every Mac on your LAN via Bonjour, and gives you one-click access to screen sharing (VNC), file sharing (SMB), SSH, and its own low-latency streaming engine called LocalCast.
+TidalDrift replaces the manual workflow of opening System Settings, toggling sharing services, remembering IP addresses, and launching Screen Sharing.app. It lives in your menu bar, discovers every Mac on your LAN via Bonjour, and provides one-click access to screen sharing (VNC), file sharing (SMB), SSH, and its own low-latency streaming engine, LocalCast.
+
+> **Development status:** LocalCast (app-window streaming) is **not yet fully implemented**. Full-desktop VNC streaming, network discovery, file transfer, clipboard sync, and all other features are functional. The custom LocalCast pipeline (ScreenCaptureKit capture, VideoToolbox encoding, Metal rendering, UDP transport) is architecturally complete and documented below, but app-window streaming has known limitations and is under active development. See [TidalDrift/LocalCast/README.md](TidalDrift/LocalCast/README.md) for details.
 
 ## Features
 
 **Menu-Bar Command Center**
-- Lives entirely in the menu bar -- no main window needed
+- Lives entirely in the menu bar; no main window needed
 - Compact popover shows your Mac's sharing status, all discovered devices, and inline action buttons
 - One-click LocalCast, VNC, SMB, and SSH connections from any device row
 - Drag files onto the Dock icon to send to multiple devices at once
 
-**LocalCast -- Low-Latency Screen Streaming**
+**LocalCast: Low-Latency Screen Streaming** *(not yet fully implemented)*
 - Custom streaming engine: ScreenCaptureKit capture, VideoToolbox H.264/HEVC encoding, Metal rendering, raw UDP transport
-- Sub-frame latency on gigabit LAN -- noticeably faster than VNC
+- Sub-frame latency on gigabit LAN
 - Stream full display or a single app window
 - End-to-end AES-256-GCM encryption with HKDF-SHA256 key derivation
 - Retina-quality with adaptive resolution (720p to 4K)
@@ -23,13 +25,13 @@ TidalDrift replaces the clunky workflow of opening System Settings, toggling sha
 
 **Network Discovery**
 - Bonjour/mDNS service browsing for `_rfb._tcp`, `_smb._tcp`, `_ssh._tcp`, and TidalDrift peers
-- Subnet scanning for devices that don't advertise services
+- Subnet scanning for devices that do not advertise services
 - Rich peer metadata broadcast (model, CPU, memory, macOS version, uptime)
 - Connection history and saved credentials in Keychain
 
-**TidalDrop -- Peer-to-Peer File Transfer**
+**TidalDrop: Peer-to-Peer File Transfer**
 - Drop files onto any device card or use the Dock icon
-- Transfers via mounted SMB share when available, falls back to direct TCP
+- Transfers via mounted SMB share when available; falls back to direct TCP
 - Configurable destination folder
 
 **Other**
@@ -69,7 +71,7 @@ chmod +x build-release.sh
 ./build-release.sh
 ```
 
-The release build adds hardened runtime, notarization via Apple's notary service, and ticket stapling. It requires a `.env` file -- see [Configuration](#configuration) below.
+The release build adds hardened runtime, notarization via Apple's notary service, and ticket stapling. It requires a `.env` file; see [Configuration](#configuration) below.
 
 To skip notarization (sign only):
 
@@ -96,7 +98,7 @@ TidalDrift requests several macOS permissions on first use:
 | **Accessibility** | Required for remote input injection (mouse/keyboard) on the host |
 | **Local Network** | Required for Bonjour discovery and direct connections |
 
-The build scripts automatically reset TCC permissions on each rebuild since code signature changes invalidate previous grants.
+The build scripts automatically reset TCC permissions on each rebuild, since code signature changes invalidate previous grants.
 
 ## Architecture
 
@@ -104,10 +106,10 @@ The build scripts automatically reset TCC permissions on each rebuild since code
 TidalDrift/
   App/                    # App entry point, delegate, state management
   Views/
-    MenuBarView.swift     # Primary UI -- menu bar popover
+    MenuBarView.swift     # Primary UI: menu bar popover
     DropTargetPicker.swift # Multi-device file send picker
     Settings/             # Settings window tabs (incl. test suite)
-    Dashboard/            # Device grid/list views (legacy, kept for reference)
+    Dashboard/            # Device grid/list views
     DeviceDetail/         # Standalone device detail windows
     Onboarding/           # First-run setup wizard
   LocalCast/
@@ -143,7 +145,7 @@ Then edit `TidalDrift/.env` with your values:
 | `APP_SPECIFIC_PASSWORD` | An app-specific password for notarytool | [appleid.apple.com](https://appleid.apple.com) > Sign-In and Security > App-Specific Passwords |
 | `NOTARY_PROFILE` | Keychain profile name (default: `notarytool-profile`) | Auto-created by the build script on first run |
 
-On the first notarization run, the script stores these credentials in your login keychain under the profile name so subsequent runs don't need the plaintext values. You can also store them manually:
+On the first notarization run, the script stores these credentials in your login keychain under the profile name, so subsequent runs do not need the plaintext values. You can also store them manually:
 
 ```bash
 xcrun notarytool store-credentials "notarytool-profile" \
@@ -154,7 +156,7 @@ xcrun notarytool store-credentials "notarytool-profile" \
 
 ### Developer ID certificate
 
-Both build scripts require a **Developer ID Application** certificate in your Keychain. The dev build (`build-app.sh`) falls back to ad-hoc signing if none is found; the release build (`build-release.sh`) will exit with an error.
+Both build scripts require a **Developer ID Application** certificate in your Keychain. The dev build (`build-app.sh`) falls back to ad-hoc signing if none is found; the release build (`build-release.sh`) exits with an error.
 
 Verify your certificate is installed:
 
@@ -166,12 +168,16 @@ security find-identity -v -p codesigning | grep "Developer ID Application"
 
 Tests run inside the app itself. Launch TidalDrift, open **Settings > Tests**, and click **Run All Tests**. The suite covers:
 
-- **Permissions** -- Screen Recording, Accessibility, network availability
-- **Bonjour** -- Service advertising, self-discovery, LocalCast UDP browse
-- **Network** -- TCP/UDP port binding, loopback echo roundtrips
-- **Security** -- Key generation, HKDF derivation, AES-GCM encrypt/decrypt, tamper detection
-- **TidalDrop** -- Loopback file transfer (small and large), destination folder validation
-- **LocalCast** -- Streaming tuning interpolation, packet protocol serialization, host session lifecycle
+- **Permissions**: Screen Recording, Accessibility, network availability
+- **Bonjour**: Service advertising, self-discovery, LocalCast UDP browse
+- **Network**: TCP/UDP port binding, loopback echo roundtrips
+- **Security**: Key generation, HKDF derivation, AES-GCM encrypt/decrypt, tamper detection
+- **TidalDrop**: Loopback file transfer (small and large), destination folder validation
+- **LocalCast**: Streaming tuning interpolation, packet protocol serialization, host session lifecycle
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow and guidelines.
 
 ## License
 

--- a/TidalDrift/LocalCast/README.md
+++ b/TidalDrift/LocalCast/README.md
@@ -1,33 +1,24 @@
-# TidalCast -- Screen & App Streaming for macOS
+# TidalCast: Screen and App Streaming for macOS
+
+> **Status:** TidalCast's full-desktop VNC streaming (Tier 1) is fully functional. App-window streaming (Tier 2) is **not yet fully implemented**. The custom pipeline described below is architecturally complete and the code compiles and runs, but app-window streaming has known limitations around window eligibility, failure diagnostics, and cross-machine reliability. Contributions are welcome.
 
 TidalCast is TidalDrift's streaming engine with a two-tier architecture:
 
 ## Tier 1: Full Desktop (VNC)
 
-Full-desktop sharing uses **macOS built-in Screen Sharing** (`vnc://`).
-Apple handles encoding, compression, input forwarding, clipboard sync,
-and authentication natively. No custom code needed -- we just open the URL.
+Full-desktop sharing uses **macOS built-in Screen Sharing** (`vnc://`). Apple handles encoding, compression, input forwarding, clipboard sync, and authentication natively. No custom code is required; TidalDrift opens the URL directly.
 
 ## Tier 2: App/Window Streaming (this code)
 
-For streaming a **single app or window** as a native-looking client window,
-TidalCast uses a custom pipeline built on Apple's low-level frameworks.
-The client picks an app from the host's window list, the host captures
-just that window via ScreenCaptureKit, encodes it with VideoToolbox, and
-sends it over UDP. The client decodes and renders in a Metal-backed NSWindow.
+For streaming a **single app or window** as a native-looking client window, TidalCast employs a custom pipeline built on Apple's low-level frameworks. The client picks an app from the host's window list, the host captures that window via ScreenCaptureKit, encodes it with VideoToolbox, and sends it over UDP. The client decodes and renders in a Metal-backed NSWindow.
 
 ## Why the custom pipeline exists
 
-VNC shares the entire desktop. When you want to treat a remote app as if
-it were running locally -- its own window, its own title bar, input scoped
-to that window -- you need per-window capture and rendering. macOS has all
-the building blocks (ScreenCaptureKit, VideoToolbox, Metal) but doesn't
-expose per-window VNC. So TidalCast wires them together.
+VNC shares the entire desktop. When the goal is to treat a remote app as if it were running locally, with its own window, its own title bar, and input scoped to that window, per-window capture and rendering are required. macOS provides the building blocks (ScreenCaptureKit, VideoToolbox, Metal) but does not expose per-window VNC. TidalCast wires them together.
 
 ## Architecture
 
-The whole pipeline runs in-process. No external daemons, no ffmpeg, no
-GStreamer. Five components, each under 500 lines:
+The pipeline runs in-process. No external daemons, no ffmpeg, no GStreamer. Five components, each under 500 lines:
 
 ```
 ┌─────────────────────── HOST ────────────────────────┐
@@ -53,117 +44,70 @@ GStreamer. Five components, each under 500 lines:
 
 ### Host side (`LocalCast/Host/`)
 
-- **ScreenCaptureManager** -- Wraps ScreenCaptureKit's `SCStream`. Supports
-  three capture modes: full display, single window, single app. Delivers
-  `CMSampleBuffer` frames to the encoder via delegate.
+- **ScreenCaptureManager**: Wraps ScreenCaptureKit's `SCStream`. Supports three capture modes: full display, single window, single app. Delivers `CMSampleBuffer` frames to the encoder via delegate.
 
-- **VideoEncoder** -- Creates a `VTCompressionSession` (H.264 or HEVC),
-  converts output from AVCC to Annex B format, prepends SPS/PPS on keyframes.
-  Real-time encoding at configurable bitrate (15-100 Mbps) and frame rate.
+- **VideoEncoder**: Creates a `VTCompressionSession` (H.264 or HEVC), converts output from AVCC to Annex B format, and prepends SPS/PPS on keyframes. Real-time encoding at configurable bitrate (15--100 Mbps) and frame rate.
 
-- **InputInjector** -- Receives normalized (0...1) mouse/keyboard coordinates
-  from the client, maps them to screen coordinates (respecting capture bounds
-  for window/app mode), and injects via `CGEvent.post(tap: .cghidEventTap)`.
-  Requires Accessibility permission. Automatically skipped on loopback
-  connections to avoid cursor feedback loops.
+- **InputInjector**: Receives normalized (0...1) mouse/keyboard coordinates from the client, maps them to screen coordinates (respecting capture bounds for window/app mode), and injects via `CGEvent.post(tap: .cghidEventTap)`. Requires Accessibility permission. Automatically skipped on loopback connections to avoid cursor feedback loops.
 
 ### Client side (`LocalCast/Client/`)
 
-- **VideoDecoder** -- Parses Annex B NAL units, extracts SPS/PPS/VPS parameter
-  sets, creates `CMVideoFormatDescription`, feeds frames to a
-  `VTDecompressionSession`. Handles both H.264 and HEVC. Auto-recreates the
-  session on resolution changes (e.g., when switching from full-display to
-  app-specific streaming).
+- **VideoDecoder**: Parses Annex B NAL units, extracts SPS/PPS/VPS parameter sets, creates `CMVideoFormatDescription`, and feeds frames to a `VTDecompressionSession`. Handles both H.264 and HEVC. Auto-recreates the session on resolution changes (e.g., when switching from full-display to app-specific streaming).
 
-- **MetalRenderer** -- Takes decoded `CVImageBuffer` frames, creates
-  `MTLTexture` via `CVMetalTextureCache`, renders a full-screen textured quad
-  with aspect-ratio-preserving scaling. Inline Metal shaders (no .metallib
-  dependency). 60fps draw loop.
+- **MetalRenderer**: Takes decoded `CVImageBuffer` frames, creates `MTLTexture` via `CVMetalTextureCache`, and renders a full-screen textured quad with aspect-ratio-preserving scaling. Inline Metal shaders (no .metallib dependency). 60fps draw loop.
 
-- **ClientSession** -- Manages the connection lifecycle: DNS resolution via
-  `ConnectionResolver`, heartbeat keep-alive, keyframe requests, input
-  forwarding, and remote app streaming commands.
+- **ClientSession**: Manages the connection lifecycle: DNS resolution via `ConnectionResolver`, heartbeat keep-alive, keyframe requests, input forwarding, and remote app streaming commands.
 
 ### Transport (`LocalCast/Transport/`)
 
-- **UDPTransport** -- Apple `Network.framework` based. UDP for minimum latency.
-  Packets larger than 1200 bytes are fragmented with a 10-byte header
-  (`frameId + fragmentIndex + totalFragments + payloadLength`). Reassembly
-  buffer holds the last 100 frame IDs.
+- **UDPTransport**: Apple `Network.framework` based. UDP for minimum latency. Packets larger than 1200 bytes are fragmented with a 10-byte header (`frameId + fragmentIndex + totalFragments + payloadLength`). Reassembly buffer holds the last 100 frame IDs.
 
-- **PacketProtocol** -- Simple binary wire format: 1-byte type + 4-byte
-  sequence + 8-byte timestamp + variable payload. Ten packet types cover
-  video, input, heartbeat, stats, and app-streaming control.
+- **PacketProtocol**: Simple binary wire format: 1-byte type + 4-byte sequence + 8-byte timestamp + variable payload. Ten packet types cover video, input, heartbeat, stats, and app-streaming control.
 
 ### Views (`LocalCast/Views/`)
 
-- **LocalCastViewerWindow** -- `NSWindowController` with an `MTKView` wrapped
-  in SwiftUI. Local + global `NSEvent` monitors capture mouse/keyboard and
-  forward as normalized coordinates. Includes a remote app picker overlay
-  for switching streams.
+- **LocalCastViewerWindow**: `NSWindowController` with an `MTKView` wrapped in SwiftUI. Local and global `NSEvent` monitors capture mouse/keyboard and forward as normalized coordinates. Includes a remote app picker overlay for switching streams.
 
-- **LocalCastSettingsView** -- Quality preset picker, codec selector,
-  permission status indicators.
+- **LocalCastSettingsView**: Quality preset picker, codec selector, permission status indicators.
 
 ### Core (`LocalCast/Core/`)
 
-- **LocalCastService** -- Singleton that manages host and client sessions.
-  Advertises via Bonjour (`dns-sd`), handles permissions, exposes
-  `@Published` state for SwiftUI binding.
+- **LocalCastService**: Singleton that manages host and client sessions. Advertises via Bonjour (`dns-sd`), handles permissions, and exposes `@Published` state for SwiftUI binding.
 
-- **LocalCastConfiguration** -- Quality presets (ultra/high/balanced/low),
-  codec selection, frame rate, adaptive quality toggle.
+- **LocalCastConfiguration**: Quality presets (ultra/high/balanced/low), codec selection, frame rate, adaptive quality toggle.
 
-- **LocalCastPermissions** -- Passive permission checking
-  (`CGPreflightScreenCaptureAccess`) plus on-demand requesting. Separated
-  to avoid the System Settings popup loop we hit during development.
+- **LocalCastPermissions**: Passive permission checking (`CGPreflightScreenCaptureAccess`) plus on-demand requesting. Separated to avoid the System Settings popup loop encountered during development.
 
-## How it works -- the happy path
+## How it works: the happy path
 
-1. User toggles **Screen Streaming** ON in the sidebar. This calls
-   `LocalCastService.startHosting()` which checks screen capture permission,
-   starts `ScreenCaptureManager` + `VideoEncoder`, and begins listening on
-   UDP port 5904. Bonjour advertisement goes out via `dns-sd`.
+1. User toggles **Screen Streaming** ON in the sidebar. This calls `LocalCastService.startHosting()`, which checks screen capture permission, starts `ScreenCaptureManager` + `VideoEncoder`, and begins listening on UDP port 5904. Bonjour advertisement goes out via `dns-sd`.
 
-2. Remote TidalDrift discovers the host via `_tidaldrift-cast._udp` Bonjour
-   service. The device card shows a yellow **LOCALCAST** button.
+2. Remote TidalDrift discovers the host via `_tidaldrift-cast._udp` Bonjour service. The device card shows a yellow **LOCALCAST** button.
 
-3. User clicks LOCALCAST. `LocalCastService.connect(to:)` creates a
-   `ClientSession` which resolves the hostname, starts heartbeats, and
-   requests keyframes.
+3. User clicks LOCALCAST. `LocalCastService.connect(to:)` creates a `ClientSession` which resolves the hostname, starts heartbeats, and requests keyframes.
 
-4. Host receives heartbeat, stores client endpoint, forces a keyframe.
-   Encoded video frames start flowing to the client over UDP.
+4. Host receives heartbeat, stores client endpoint, and forces a keyframe. Encoded video frames start flowing to the client over UDP.
 
-5. Client receives frames, decodes via VideoToolbox, renders via Metal.
-   The viewer window opens showing the remote screen.
+5. Client receives frames, decodes via VideoToolbox, and renders via Metal. The viewer window opens showing the remote screen.
 
-6. Mouse/keyboard events in the viewer are captured by `NSEvent` monitors,
-   normalized to 0...1 coordinates, serialized, and sent to the host as
-   `inputEvent` packets. The host deserializes and injects via `CGEvent`.
+6. Mouse/keyboard events in the viewer are captured by `NSEvent` monitors, normalized to 0...1 coordinates, serialized, and sent to the host as `inputEvent` packets. The host deserializes and injects via `CGEvent`.
 
-7. User can click **Apps** in the viewer toolbar to browse remote apps.
-   The host enumerates running apps via `SCShareableContent` and sends the
-   list. Clicking an app sends a `streamAppRequest`; the host stops the
-   current capture and starts a new one targeting just that app.
+7. User can click **Apps** in the viewer toolbar to browse remote apps. The host enumerates running apps via `SCShareableContent` and sends the list. Clicking an app sends a `streamAppRequest`; the host stops the current capture and starts a new one targeting that app.
 
 ## Loopback demo mode
 
-For development and demos, a **loopback device** (127.0.0.1) can be added
-via Add Device > Add Loopback Device (DEBUG builds only). This proves the
-full pipeline on a single machine:
+For development and demos, a **loopback device** (127.0.0.1) can be added via Add Device > Add Loopback Device (DEBUG builds only). This exercises the full pipeline on a single machine:
 
 - Video: capture -> encode -> UDP -> decode -> Metal render
-- Input: event capture -> serialize -> UDP -> deserialize (injection skipped
-  on loopback to avoid cursor feedback)
-- App switching: full display <-> specific app
+- Input: event capture -> serialize -> UDP -> deserialize (injection skipped on loopback to avoid cursor feedback)
+- App switching: full display to specific app
 
-## Build & run
+## Build and run
 
 ```bash
 cd TidalDrift
-bash build-app.sh          # Build, sign, DMG, install to /Applications, launch
-bash build-app.sh --no-run  # Build only, don't launch
+bash build-app.sh           # Build, sign, DMG, install to /Applications, launch
+bash build-app.sh --no-run  # Build only, do not launch
 ```
 
 The build script:
@@ -174,44 +118,25 @@ The build script:
 
 ## Key decisions and tradeoffs
 
-**UDP over TCP** -- We chose UDP for the video transport because TCP's
-congestion control and retransmission add latency that's worse than dropping
-a frame. Lost fragments simply mean a dropped frame; the next keyframe
-(every ~1 second) resyncs. Input events are also UDP (fire-and-forget),
-which is acceptable for mouse moves -- clicks could theoretically be lost
-but in practice on a LAN this doesn't happen.
+**UDP over TCP.** UDP was chosen for the video transport because TCP's congestion control and retransmission add latency worse than dropping a frame. Lost fragments result in a dropped frame; the next keyframe (approximately every 1 second) resyncs. Input events are also UDP (fire-and-forget), which is acceptable for mouse moves. Clicks could theoretically be lost, but on a LAN this does not occur in practice.
 
-**Annex B over AVCC** -- VideoToolbox outputs AVCC (length-prefixed NAL
-units), but we convert to Annex B (start-code delimited) on the wire. This
-makes the stream self-describing -- the decoder can find NAL boundaries
-without out-of-band signaling, and SPS/PPS are inline with keyframes.
+**Annex B over AVCC.** VideoToolbox outputs AVCC (length-prefixed NAL units), but the pipeline converts to Annex B (start-code delimited) on the wire. This makes the stream self-describing: the decoder can find NAL boundaries without out-of-band signaling, and SPS/PPS are inline with keyframes.
 
-**Inline Metal shaders** -- We compile shaders from source strings at init
-time rather than shipping a `.metallib`. This avoids SPM resource bundling
-headaches and means the renderer works in any build configuration.
+**Inline Metal shaders.** Shaders are compiled from source strings at init time rather than shipped as a `.metallib`. This avoids SPM resource bundling issues and ensures the renderer works in any build configuration.
 
-**1200-byte fragment size** -- Chosen to stay under typical MTU (1500) with
-room for IP/UDP headers. Larger frames (keyframes can be 300KB+) get split
-into ~250 fragments. Reassembly is frame-ID based with a 100-frame LRU.
+**1200-byte fragment size.** Chosen to stay under typical MTU (1500) with room for IP/UDP headers. Larger frames (keyframes can exceed 300 KB) are split into approximately 250 fragments. Reassembly is frame-ID based with a 100-frame LRU.
 
-**No audio (yet)** -- `LocalCastConfiguration.captureAudio` exists but is
-`false`. ScreenCaptureKit supports audio capture; wiring it through is
-straightforward but wasn't needed for the initial release.
+**No audio (yet).** `LocalCastConfiguration.captureAudio` exists but is set to `false`. ScreenCaptureKit supports audio capture; wiring it through is straightforward but was not needed for the initial release.
 
 ## Permissions
 
-- **Screen Recording** -- Required for `SCStream`. Checked via
-  `CGPreflightScreenCaptureAccess()`, requested via
-  `CGRequestScreenCaptureAccess()` only on explicit user action.
+- **Screen Recording**: Required for `SCStream`. Checked via `CGPreflightScreenCaptureAccess()`, requested via `CGRequestScreenCaptureAccess()` only on explicit user action.
 
-- **Accessibility** -- Required for `CGEvent.post()` input injection. Optional
-  for streaming-only use. Checked via `AXIsProcessTrusted()`.
+- **Accessibility**: Required for `CGEvent.post()` input injection. Optional for streaming-only use. Checked via `AXIsProcessTrusted()`.
 
-- **Local Network** -- Required for Bonjour discovery and UDP transport.
-  Declared in `Info.plist` via `NSLocalNetworkUsageDescription` and
-  `NSBonjourServices`.
+- **Local Network**: Required for Bonjour discovery and UDP transport. Declared in `Info.plist` via `NSLocalNetworkUsageDescription` and `NSBonjourServices`.
 
-## What's next
+## What is next
 
 - Audio capture and forwarding
 - Latency measurement from heartbeat RTT


### PR DESCRIPTION
## Summary

- Replace emdash (`--`) usage with proper punctuation (commas, semicolons, colons, separate sentences) across `README.md`, `CONTRIBUTING.md`, and `TidalDrift/LocalCast/README.md` to comply with writing style conventions.
- Add a prominent development status notice to the root README and LocalCast README flagging that LocalCast app-window streaming is **not yet fully implemented**.
- Add LocalCast as a contribution area in `CONTRIBUTING.md` to direct open-source contributors toward the most impactful work.

Closes #20

## Test plan

- [ ] README.md renders correctly on GitHub (no broken links, tables, or formatting)
- [ ] CONTRIBUTING.md renders correctly
- [ ] TidalDrift/LocalCast/README.md renders correctly
- [ ] No emdash (`--` used as punctuation) remains in any updated file
- [ ] LocalCast status notice is visible in both the root README and LocalCast README