### PR TITLE
chore: add SwiftLint, CI workflow, and branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: SwiftLint
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        working-directory: TidalDrift
+        run: swiftlint lint --reporter github-actions-logging
+
+  build:
+    name: Build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+
+      - name: Build with Swift Package Manager
+        working-directory: TidalDrift
+        run: swift build

--- a/TidalDrift/.swiftlint.yml
+++ b/TidalDrift/.swiftlint.yml
@@ -1,0 +1,114 @@
+# SwiftLint configuration for TidalDrift
+# Thresholds are set to pass on the existing codebase while catching
+# regressions in new code. Tighten over time as violations are cleaned up.
+
+included:
+  - App
+  - Views
+  - ViewModels
+  - Services
+  - Models
+  - Utilities
+  - LocalCast
+  - Extensions
+
+excluded:
+  - .build
+  - build-xcode
+  - dist
+  - Scripts
+  - PressKit
+  - Resources
+
+# Rules that produce too much noise on the existing codebase.
+# Re-enable as the code is cleaned up.
+disabled_rules:
+  - trailing_whitespace
+  - trailing_newline
+  - multiple_closures_with_trailing_closure
+  - todo
+
+opt_in_rules:
+  - closure_spacing
+  - empty_string
+  - fatal_error_message
+  - first_where
+  - implicit_return
+  - modifier_order
+  - overridden_super_call
+  - private_over_fileprivate
+  - redundant_nil_coalescing
+  - sorted_first_last
+  - unowned_variable_capture
+  - vertical_parameter_alignment_on_call
+
+line_length:
+  warning: 160
+  error: 300
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+file_length:
+  warning: 600
+  error: 1600
+
+type_body_length:
+  warning: 400
+  error: 1200
+
+function_body_length:
+  warning: 60
+  error: 150
+
+cyclomatic_complexity:
+  warning: 15
+  error: 30
+
+identifier_name:
+  min_length:
+    warning: 1
+    error: 0
+  max_length:
+    warning: 60
+    error: 80
+  allowed_symbols:
+    - _
+  excluded:
+    - i
+    - j
+    - k
+    - x
+    - y
+    - id
+    - ip
+    - ok
+    - to
+    - n
+
+type_name:
+  min_length:
+    warning: 3
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+
+large_tuple:
+  warning: 4
+  error: 6
+
+force_cast:
+  severity: warning
+
+function_parameter_count:
+  warning: 6
+  error: 10
+
+nesting:
+  type_level:
+    warning: 2
+    error: 4
+  function_level:
+    warning: 3
+    error: 5


### PR DESCRIPTION
## Summary

- Add **SwiftLint configuration** (`TidalDrift/.swiftlint.yml`) with pragmatic thresholds: 0 errors on the existing codebase, 173 warnings. Noisy rules (trailing_whitespace, trailing_newline) are disabled and can be re-enabled after a cleanup pass. Opt-in rules for closure spacing, modifier order, and redundant nil coalescing are enabled.
- Add **GitHub Actions CI workflow** (`.github/workflows/ci.yml`) with two jobs: SwiftLint and `swift build`, running on `macos-15` for every PR and push to `main`.
- **Branch protection** enabled on `main` via API: requires PRs (no direct push), requires SwiftLint and Build status checks to pass, dismisses stale reviews, no force pushes.

Closes #22

## Test plan

- [ ] CI workflow runs on this PR (SwiftLint job + Build job)
- [ ] SwiftLint exits 0 (no errors)
- [ ] `swift build` succeeds
- [ ] After merge, direct push to `main` is rejected
- [ ] Future PRs require passing CI checks