### PR TITLE
fix: Settings window not coming to front, screen share ~60s latency

### DIFF
--- a/TidalDrift/App/AppDelegate.swift
+++ b/TidalDrift/App/AppDelegate.swift
@@ -72,9 +72,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
     
     func showOnboarding() {
+        NSApp.activate(ignoringOtherApps: true)
         if let existing = onboardingWindow {
+            existing.orderFrontRegardless()
             existing.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
             return
         }
         
@@ -114,9 +115,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
     
     private func showSettings() {
+        NSApp.activate(ignoringOtherApps: true)
         if let existing = settingsWindow {
+            existing.orderFrontRegardless()
             existing.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
             return
         }
         

--- a/TidalDrift/Services/ScreenShareConnectionService.swift
+++ b/TidalDrift/Services/ScreenShareConnectionService.swift
@@ -86,8 +86,8 @@ class ScreenShareConnectionService: @unchecked Sendable {
         do {
             resolved = try await ConnectionResolver.shared.resolve(
                 device: device,
-                strategy: .hostnameFirst,
-                timeout: 10.0
+                strategy: .ipFirst,
+                timeout: 5.0
             )
             logger.info("🔌 Resolved address: \(resolved.address) via \(resolved.method.rawValue)")
         } catch let error as ConnectionResolver.ResolutionError {
@@ -249,8 +249,8 @@ class ScreenShareConnectionService: @unchecked Sendable {
         do {
             resolved = try await ConnectionResolver.shared.resolve(
                 device: device,
-                strategy: .hostnameFirst,
-                timeout: 10.0
+                strategy: .ipFirst,
+                timeout: 5.0
             )
         } catch let error as ConnectionResolver.ResolutionError {
             throw ConnectionError.resolutionFailed(error.localizedDescription)
@@ -303,8 +303,8 @@ class ScreenShareConnectionService: @unchecked Sendable {
         do {
             resolved = try await ConnectionResolver.shared.resolve(
                 device: device,
-                strategy: .hostnameFirst,
-                timeout: 10.0
+                strategy: .ipFirst,
+                timeout: 5.0
             )
         } catch let error as ConnectionResolver.ResolutionError {
             throw ConnectionError.resolutionFailed(error.localizedDescription)
@@ -388,7 +388,7 @@ class ScreenShareConnectionService: @unchecked Sendable {
                 // Try to resolve using hostname-first strategy
                 let resolved = try await ConnectionResolver.shared.resolve(
                     device: device,
-                    strategy: .hostnameFirst,
+                    strategy: .ipFirst,
                     timeout: 5.0
                 )
                 // Use hostname.local for SSH if available (more reliable)
@@ -451,8 +451,8 @@ class ScreenShareConnectionService: @unchecked Sendable {
         do {
             _ = try await ConnectionResolver.shared.resolve(
                 device: device,
-                strategy: .hostnameFirst,
-                timeout: 8.0
+                strategy: .ipFirst,
+                timeout: 5.0
             )
             // If we successfully resolved, the device is reachable
             return true


### PR DESCRIPTION
## Summary
- Fix Settings/Wizard windows not coming to front when the app is in the background
- Fix ~60s screen share connection delay by switching to ipFirst resolution strategy

## Changes

**Settings focus (AppDelegate.swift):**
- Call `NSApp.activate(ignoringOtherApps:)` before window operations, not after
- Use `orderFrontRegardless()` for existing windows that may be behind other apps

**Screen share latency (ScreenShareConnectionService.swift):**
- Switch all connection resolution from `hostnameFirst` to `ipFirst` strategy
- Reduce timeout from 10s to 5s
- The `hostnameFirst` strategy ran up to 3 sequential `getaddrinfo` calls on `.local` hostnames, each blocking for the full sub-timeout. Since Bonjour already provides a current IP, using it directly eliminates the mDNS re-resolution overhead.

## Test plan
- [x] swift build passes
- [ ] Open Settings from menu bar while another app is focused
- [ ] Screen share connects in under 5s on same subnet