### PR TITLE
fix: close menu popover before quick device actions

### DIFF
--- a/TidalDrift/Views/MenuBarView.swift
+++ b/TidalDrift/Views/MenuBarView.swift
@@ -308,6 +308,18 @@ struct MenuBarDeviceRow: View {
         return creds.password.isEmpty ? nil : creds.password
     }
     
+    /// Close the status-bar popover before opening external apps/URLs.
+    private func dismissPopoverAndRun(_ action: @escaping () -> Void) {
+        if let popover = NSApp.keyWindow,
+           popover.level == .statusBar || popover.styleMask.contains(.nonactivatingPanel) || popover.className.contains("StatusBar") {
+            popover.close()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            NSApp.activate(ignoringOtherApps: true)
+            action()
+        }
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 8) {
@@ -332,16 +344,22 @@ struct MenuBarDeviceRow: View {
                 if isHovering {
                     HStack(spacing: 4) {
                         QuickActionIcon(icon: "display", color: .blue, tooltip: "Screen Share (VNC)") {
-                            Task { try? await ScreenShareConnectionService.shared.connect(to: device) }
+                            dismissPopoverAndRun {
+                                Task { try? await ScreenShareConnectionService.shared.connect(to: device) }
+                            }
                         }
                         
                         QuickActionIcon(icon: "folder", color: .orange, tooltip: "File Share") {
-                            Task { try? await ScreenShareConnectionService.shared.connectToFileShare(device: device) }
+                            dismissPopoverAndRun {
+                                Task { try? await ScreenShareConnectionService.shared.connectToFileShare(device: device) }
+                            }
                         }
                         
                         if showSSH {
                             QuickActionIcon(icon: "terminal", color: .green, tooltip: "SSH") {
-                                ScreenShareConnectionService.shared.connectToSSH(device: device)
+                                dismissPopoverAndRun {
+                                    ScreenShareConnectionService.shared.connectToSSH(device: device)
+                                }
                             }
                         }
                         


### PR DESCRIPTION
## Summary
- Close the status-bar popover before running quick device row actions in the menu.
- Route screen share, file share, and SSH icons through the same dismissal flow used by working menu actions.
- Prevent no-op clicks caused by launching external actions while the non-activating popover still owns focus.

## Test plan
- [x] Open the menu and click Screen Share on a discovered device.
- [x] Open the menu and click File Share on a discovered device.
- [x] Open the menu and click SSH on a discovered device.
- [x] Confirm the info icon still opens device details.
- [x] Run `swift build` in `TidalDrift/`.
- [ ] Run `pre-commit run --all-files` (not available in this environment).