### PR TITLE
fix: restore settings window launch and add env template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ TidalDrift/TidalDrift\ *.app/
 .env
 *.env
 !.env.example
+!.env.template
 !TidalDrift/version.env
 
 # Build artifacts from build-app.sh / build-release.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for your interest in contributing to TidalDrift. This document covers 
 - Releases are automated: publishing a GitHub Release triggers a workflow that builds, signs, notarizes, uploads the DMG, and bumps the Homebrew cask.
 - The release workflow requires maintainer approval via a protected GitHub environment.
 - Build version metadata is sourced from `TidalDrift/version.env` (`APP_VERSION`, `BUILD_NUMBER`).
-- For local release builds, `build-release.sh` loads credentials from `TidalDrift/.env` (never committed). Pass `--skip-notarize` to skip Apple notarization.
+- For local release builds, copy `TidalDrift/.env.template` to `TidalDrift/.env`, then fill in credentials. `build-release.sh` loads `TidalDrift/.env` (never committed). Pass `--skip-notarize` to skip Apple notarization.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ BUILD_NUMBER=10403
 The release build script sources `TidalDrift/.env` for Apple notarization credentials. This file is gitignored and must never be committed.
 
 ```bash
-cp TidalDrift/.env.example TidalDrift/.env
+cp TidalDrift/.env.template TidalDrift/.env
 ```
 
 Then edit `TidalDrift/.env` with your values:

--- a/TidalDrift/.env.example
+++ b/TidalDrift/.env.example
@@ -1,8 +1,10 @@
-# TidalDrift Notarization Credentials
-# Copy this file to .env and fill in your values
-# DO NOT commit .env to version control
+# TidalDrift local release environment template (legacy alias)
+# Prefer .env.template for new setup; this file is kept for compatibility.
+# Copy this file to .env and fill in your values.
+# Do not commit .env to version control.
 
 APPLE_ID="your-apple-id@example.com"
 TEAM_ID="YOUR_TEAM_ID"
 APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
 NOTARY_PROFILE="notarytool-profile"
+COPY_TO_SHARE="0"

--- a/TidalDrift/.env.template
+++ b/TidalDrift/.env.template
@@ -1,0 +1,16 @@
+# TidalDrift local release environment template
+# Copy this file to .env, then fill in your real values.
+# Never commit .env.
+
+# Apple notarization credentials used by build-release.sh.
+APPLE_ID="your-apple-id@example.com"
+TEAM_ID="YOUR_TEAM_ID"
+APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+
+# Optional: keychain profile name used by notarytool.
+# Default is "notarytool-profile" when omitted.
+NOTARY_PROFILE="notarytool-profile"
+
+# Optional: set to 1 to copy the built DMG to the maintainer SMB share.
+# Default is 0.
+COPY_TO_SHARE="0"

--- a/TidalDrift/.gitignore
+++ b/TidalDrift/.gitignore
@@ -33,6 +33,7 @@ xcuserdata/
 # Environment secrets
 .env
 !.env.example
+!.env.template
 
 # Build output from build-app.sh
 build-xcode/

--- a/TidalDrift/App/AppDelegate.swift
+++ b/TidalDrift/App/AppDelegate.swift
@@ -117,6 +117,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private func showSettings() {
         NSApp.activate(ignoringOtherApps: true)
         if let existing = settingsWindow {
+            if existing.isMiniaturized {
+                existing.deminiaturize(nil)
+            }
+            existing.level = .floating
             existing.orderFrontRegardless()
             existing.makeKeyAndOrderFront(nil)
             return
@@ -137,7 +141,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         window.contentView = hostingView
         window.center()
         window.isReleasedWhenClosed = false
+        window.level = .floating
+        window.collectionBehavior.insert(.moveToActiveSpace)
         window.delegate = self
+        window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
         
         NSApp.activate(ignoringOtherApps: true)

--- a/TidalDrift/Package.swift
+++ b/TidalDrift/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executableTarget(
             name: "TidalDrift",
             path: ".",
-            exclude: ["build-release.sh", ".env", ".env.example", "TidalDrift.entitlements", "Info.plist", "Package.swift", "build-app.sh", "Resources/AppIcon.iconset", "Scripts", "PressKit", "dist", "drop", "bump-version.sh"],
+            exclude: ["build-release.sh", ".env", ".env.example", ".env.template", "TidalDrift.entitlements", "Info.plist", "Package.swift", "build-app.sh", "Resources/AppIcon.iconset", "Scripts", "PressKit", "dist", "drop", "bump-version.sh"],
             sources: [
                 "App",
                 "Views",

--- a/TidalDrift/Views/MenuBarView.swift
+++ b/TidalDrift/Views/MenuBarView.swift
@@ -39,7 +39,12 @@ struct MenuBarView: View {
     /// Close the menu bar popover, then run an action on the next run loop
     /// so the target window can become key without competing for focus.
     private func dismissPopoverAndRun(_ action: @escaping () -> Void) {
-        if let popover = NSApp.keyWindow, popover.level == .statusBar || popover.styleMask.contains(.nonactivatingPanel) || popover.className.contains("StatusBar") {
+        if let popover = NSApp.windows.first(where: {
+            $0.isVisible
+                && ($0.level == .statusBar
+                    || $0.styleMask.contains(.nonactivatingPanel)
+                    || $0.className.contains("StatusBar"))
+        }) {
             popover.close()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
@@ -224,7 +229,7 @@ struct MenuBarView: View {
             
             MenuBarActionButton(icon: "gearshape", label: "Settings...") {
                 dismissPopoverAndRun {
-                    (NSApp.delegate as? AppDelegate)?.showSettingsWindow(nil)
+                    NSApp.sendAction(#selector(AppDelegate.showSettingsWindow(_:)), to: nil, from: nil)
                 }
             }
             


### PR DESCRIPTION
## Summary
- Fix menu-bar Settings so it reliably opens, becomes key, and stays in front when launched from the popover.
- Add `TidalDrift/.env.template` as the canonical checked-in local release template.
- Update docs and ignore/package metadata to point to `.env.template` while keeping `.env.example` as a compatibility alias.

## Test plan
- [x] Click **Settings...** from the menu bar and verify window appears quickly and on top.
- [x] Confirm existing Settings window is restored from minimized state and brought front.
- [x] Run `swift build` in `TidalDrift/`.
- [x] Copy template: `cp TidalDrift/.env.template TidalDrift/.env`.