### PR TITLE
chore: ignore Swift profraw output

### DIFF
--- a/TidalDrift/.gitignore
+++ b/TidalDrift/.gitignore
@@ -40,3 +40,6 @@ build-xcode/
 dist/
 drop/
 
+# Swift profiling output
+*.profraw
+


### PR DESCRIPTION
Adds *.profraw to .gitignore so build-time profiling output stops appearing as untracked.