### PR TITLE
feat: tidaldrift-pi Debian package for Raspberry Pi targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ TidalDrift/TidalDrift\ *.app/
 
 # Cursor project metadata
 .cursor/
+linux/tidaldrift-pi/*.deb

--- a/linux/tidaldrift-pi/build-deb.sh
+++ b/linux/tidaldrift-pi/build-deb.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Build tidaldrift-pi_<version>_all.deb from the pkg/ tree.
+# Works on macOS (brew install dpkg) and on Debian.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$SCRIPT_DIR/pkg"
+VERSION=$(awk -F': ' '/^Version:/ {print $2}' "$PKG_DIR/DEBIAN/control")
+OUT="$SCRIPT_DIR/tidaldrift-pi_${VERSION}_all.deb"
+
+command -v dpkg-deb >/dev/null || { echo "dpkg-deb not found (macOS: brew install dpkg)"; exit 1; }
+
+# Stage into a temp tree so we can set ownership/permissions without
+# touching the checked-in files (dpkg-deb --root-owner-group handles
+# ownership; permissions still need to be right on disk).
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+cp -R "$PKG_DIR/" "$STAGE/pkg"
+
+chmod 0755 "$STAGE/pkg/DEBIAN/postinst" "$STAGE/pkg/DEBIAN/prerm" "$STAGE/pkg/DEBIAN/postrm"
+chmod 0755 "$STAGE/pkg/usr/bin/tidaldrift-pi-setup"
+chmod 0644 "$STAGE/pkg/DEBIAN/control" "$STAGE/pkg/DEBIAN/conffiles"
+find "$STAGE/pkg/etc" "$STAGE/pkg/lib" "$STAGE/pkg/usr/share" -type f -exec chmod 0644 {} +
+find "$STAGE/pkg" -name .DS_Store -delete
+
+dpkg-deb --root-owner-group --build "$STAGE/pkg" "$OUT"
+echo ""
+echo "Built: $OUT"
+echo "Install on the Pi:"
+echo "  scp '$OUT' <user>@raspberrypi.local:/tmp/"
+echo "  ssh <user>@raspberrypi.local 'sudo apt install -y /tmp/$(basename "$OUT") && sudo tidaldrift-pi-setup <user>'"

--- a/linux/tidaldrift-pi/pkg/DEBIAN/conffiles
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/conffiles
@@ -1,0 +1,2 @@
+/etc/avahi/services/tidaldrift-ssh.service
+/etc/avahi/services/tidaldrift-rfb.service

--- a/linux/tidaldrift-pi/pkg/DEBIAN/control
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/control
@@ -1,0 +1,20 @@
+Package: tidaldrift-pi
+Version: 0.1.0
+Section: net
+Priority: optional
+Architecture: all
+Depends: avahi-daemon, tigervnc-standalone-server
+Recommends: openssh-server
+Maintainer: Goldberg Consulting, LLC <releases@measured.one>
+Description: TidalDrift companion for Raspberry Pi and other Debian systems
+ Makes a Linux machine a first-class target in TidalDrift on macOS.
+ Advertises SSH and VNC over Bonjour (_ssh._tcp, _rfb._tcp) so the
+ machine appears in the TidalDrift device list with working SSH and
+ Screen Share buttons, and runs a TigerVNC virtual desktop pinned to
+ port 5900 for macOS Screen Sharing to connect to.
+ .
+ Also publishes a TidalDrift peer beacon (_tidaldrift._tcp) with a
+ stable per-install peer ID and hardware metadata, so saved logins on
+ the Mac survive DHCP lease changes on this machine.
+ .
+ After installing, run: sudo tidaldrift-pi-setup <username>

--- a/linux/tidaldrift-pi/pkg/DEBIAN/postinst
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/postinst
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+xml_escape() {
+    printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+}
+
+PEER_DIR=/etc/tidaldrift
+PEER_ID_FILE=$PEER_DIR/peer-id
+
+# Stable per-install identity. TidalDrift on macOS keys saved credentials
+# by this ID, so it must survive reinstalls and upgrades; only a purge
+# removes it.
+mkdir -p "$PEER_DIR"
+if [ ! -s "$PEER_ID_FILE" ]; then
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' > "$PEER_ID_FILE"
+    else
+        cat /proc/sys/kernel/random/uuid > "$PEER_ID_FILE"
+    fi
+    chmod 0644 "$PEER_ID_FILE"
+fi
+PEER_ID=$(cat "$PEER_ID_FILE")
+
+MODEL="Linux"
+if [ -r /proc/device-tree/model ]; then
+    MODEL=$(tr -d '\0' < /proc/device-tree/model)
+fi
+OS="Linux"
+if [ -r /etc/os-release ]; then
+    OS=$(. /etc/os-release && printf '%s' "$PRETTY_NAME")
+fi
+
+# The peer beacon is metadata-only: TidalDrift reads the TXT records via
+# Bonjour and never connects to the advertised port. Generated here (not a
+# shipped conffile) because the peer ID and hardware strings are per-machine.
+cat > /etc/avahi/services/tidaldrift-peer.service <<EOF
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_tidaldrift._tcp</type>
+    <port>5959</port>
+    <txt-record>peerId=$(xml_escape "$PEER_ID")</txt-record>
+    <txt-record>model=$(xml_escape "$MODEL")</txt-record>
+    <txt-record>os=$(xml_escape "$OS")</txt-record>
+    <txt-record>version=0.1.0</txt-record>
+    <txt-record>screen=1</txt-record>
+    <txt-record>file=0</txt-record>
+  </service>
+</service-group>
+EOF
+
+systemctl daemon-reload >/dev/null 2>&1 || true
+if systemctl is-active --quiet avahi-daemon 2>/dev/null; then
+    systemctl reload-or-restart avahi-daemon >/dev/null 2>&1 || true
+fi
+
+echo ""
+echo "tidaldrift-pi installed. This machine now advertises SSH over Bonjour."
+echo "To enable the VNC virtual desktop (Screen Share button on the Mac):"
+echo ""
+echo "    sudo tidaldrift-pi-setup <username>"
+echo ""
+
+exit 0

--- a/linux/tidaldrift-pi/pkg/DEBIAN/postrm
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/postrm
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+case "$1" in
+    remove|purge)
+        rm -f /etc/avahi/services/tidaldrift-peer.service
+        if [ "$1" = "purge" ]; then
+            # The peer ID is this machine's saved-credential identity on the
+            # Mac side; only purge discards it.
+            rm -rf /etc/tidaldrift
+        fi
+        systemctl daemon-reload >/dev/null 2>&1 || true
+        if systemctl is-active --quiet avahi-daemon 2>/dev/null; then
+            systemctl reload-or-restart avahi-daemon >/dev/null 2>&1 || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/linux/tidaldrift-pi/pkg/DEBIAN/prerm
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/prerm
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+if [ "$1" = "remove" ] || [ "$1" = "purge" ] || [ "$1" = "deconfigure" ]; then
+    # Stop and disable every per-user VNC instance, best effort.
+    systemctl list-units --type=service --all --plain --no-legend 'tidaldrift-vnc@*' 2>/dev/null \
+        | awk '{print $1}' \
+        | while read -r unit; do
+            [ -n "$unit" ] || continue
+            systemctl stop "$unit" >/dev/null 2>&1 || true
+            systemctl disable "$unit" >/dev/null 2>&1 || true
+        done
+fi
+
+exit 0

--- a/linux/tidaldrift-pi/pkg/etc/avahi/services/tidaldrift-rfb.service
+++ b/linux/tidaldrift-pi/pkg/etc/avahi/services/tidaldrift-rfb.service
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!-- Advertise VNC (RFB) so TidalDrift on macOS shows a Screen Share
+     button. The TigerVNC virtual desktop from tidaldrift-pi-setup is
+     pinned to port 5900, which is also what macOS Screen Sharing
+     expects by default. -->
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_rfb._tcp</type>
+    <port>5900</port>
+  </service>
+</service-group>

--- a/linux/tidaldrift-pi/pkg/etc/avahi/services/tidaldrift-ssh.service
+++ b/linux/tidaldrift-pi/pkg/etc/avahi/services/tidaldrift-ssh.service
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!-- Advertise SSH so TidalDrift on macOS shows this machine with an SSH
+     button. Avahi substitutes the hostname for %h. -->
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+</service-group>

--- a/linux/tidaldrift-pi/pkg/lib/systemd/system/tidaldrift-vnc@.service
+++ b/linux/tidaldrift-pi/pkg/lib/systemd/system/tidaldrift-vnc@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=TidalDrift VNC virtual desktop for %i (TigerVNC on port 5900)
+After=network.target avahi-daemon.service
+
+[Service]
+Type=forking
+User=%i
+WorkingDirectory=~
+# No PIDFile: tigervncserver names its pid file after the machine's FQDN,
+# which does not reliably match systemd's %H; Type=forking main-PID
+# detection plus ExecStop's clean kill are sufficient.
+# Virtual desktop on display :1, but pinned to port 5900 so macOS Screen
+# Sharing (and TidalDrift's advertised _rfb._tcp port) connect without a
+# display-number port offset. -localhost no exposes it on the LAN; access
+# is gated by the VNC password created by tidaldrift-pi-setup.
+ExecStartPre=/bin/sh -c 'test -s "/home/%i/.config/tigervnc/passwd" || test -s "/home/%i/.vnc/passwd" || { echo "No VNC password set. Run: sudo tidaldrift-pi-setup %i"; exit 1; }'
+ExecStart=/usr/bin/tigervncserver :1 -rfbport 5900 -localhost no -geometry 1920x1080 -depth 24
+ExecStop=/usr/bin/tigervncserver -kill :1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/linux/tidaldrift-pi/pkg/usr/bin/tidaldrift-pi-setup
+++ b/linux/tidaldrift-pi/pkg/usr/bin/tidaldrift-pi-setup
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Finish tidaldrift-pi setup for one user: set the VNC password and start
+# the virtual desktop service. Run as root: sudo tidaldrift-pi-setup <user>
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Run as root: sudo tidaldrift-pi-setup <username>" >&2
+    exit 1
+fi
+
+USER_NAME="${1:-${SUDO_USER:-}}"
+if [ -z "$USER_NAME" ] || ! id "$USER_NAME" >/dev/null 2>&1; then
+    echo "Usage: sudo tidaldrift-pi-setup <username>" >&2
+    exit 1
+fi
+
+echo "Setting the VNC password for $USER_NAME (used by macOS Screen Sharing)."
+su - "$USER_NAME" -c vncpasswd
+
+systemctl enable --now "tidaldrift-vnc@${USER_NAME}.service"
+systemctl reload-or-restart avahi-daemon
+
+HOSTNAME_LOCAL="$(hostname).local"
+echo ""
+echo "Done. This machine now advertises SSH and Screen Sharing over Bonjour."
+echo "From the Mac: it appears in TidalDrift as '$(hostname)', or connect"
+echo "directly with vnc://${HOSTNAME_LOCAL} and ssh ${USER_NAME}@${HOSTNAME_LOCAL}"
+echo ""
+echo "The VNC session is a virtual desktop (no monitor needed), 1920x1080,"
+echo "TCP 5900, password-protected. Traffic is not encrypted; keep it on"
+echo "the local network."

--- a/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
+++ b/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
@@ -1,0 +1,38 @@
+# tidaldrift-pi
+
+Companion package that makes a Raspberry Pi (or any Debian-family machine)
+a first-class target for TidalDrift on macOS: the Pi shows up in the
+device list with working SSH and Screen Share buttons.
+
+## What it installs
+
+| Piece | Purpose |
+|---|---|
+| `/etc/avahi/services/tidaldrift-ssh.service` | Advertises `_ssh._tcp` (port 22) over Bonjour |
+| `/etc/avahi/services/tidaldrift-rfb.service` | Advertises `_rfb._tcp` (port 5900) over Bonjour |
+| `/etc/avahi/services/tidaldrift-peer.service` | TidalDrift peer beacon (`_tidaldrift._tcp`) with a stable `peerId` and hardware metadata, generated at install time |
+| `tidaldrift-vnc@.service` | TigerVNC virtual desktop, per user, pinned to port 5900 |
+| `tidaldrift-pi-setup` | One-time helper: sets the VNC password and starts the service |
+
+## Install
+
+```bash
+sudo apt install -y ./tidaldrift-pi_0.1.0_all.deb
+sudo tidaldrift-pi-setup <username>
+```
+
+`tigervnc-standalone-server` and `avahi-daemon` come in as dependencies.
+The setup step prompts for a VNC password (this is what macOS Screen
+Sharing asks for when connecting).
+
+## Notes
+
+- The VNC session is a **virtual desktop** (1920x1080): it works headless,
+  with no monitor attached, and is independent of anything on the Pi's
+  physical display. To share the physical Wayland desktop instead, use
+  `wayvnc` and keep only this package's Avahi advertisements.
+- The stable peer ID in the beacon means TidalDrift keys this machine's
+  saved login by identity, not IP, so credentials survive DHCP changes.
+  `apt remove` keeps the ID; `apt purge` discards it.
+- RFB traffic is password-gated but not encrypted. Treat it as a
+  LAN-only service; for remote access, tunnel over SSH.


### PR DESCRIPTION
## Summary
- New `linux/tidaldrift-pi/` Debian package source: Avahi service files advertising `_ssh._tcp` (22) and `_rfb._tcp` (5900), a per-user `tidaldrift-vnc@.service` TigerVNC virtual desktop pinned to port 5900, a `_tidaldrift._tcp` peer beacon generated at install time with a persisted `peerId` (survives upgrades, removed only on purge), and a `tidaldrift-pi-setup` helper that sets the VNC password and starts the service.
- `build-deb.sh` builds the `.deb` on macOS (Homebrew dpkg) or Debian; built artifacts are gitignored.
- No Mac-side code changes: TidalDrift already browses `_ssh._tcp`/`_rfb._tcp`, honors the advertised RFB port through `ConnectionResolver`, and keys credentials by `peerId` (#118).

Closes #119

## Test plan
- [x] `dpkg-deb --build` succeeds; `--info`/`--contents` verified
- [x] `sh -n` on all maintainer scripts; `xmllint` on Avahi service files
- [ ] On the Pi: `apt install ./tidaldrift-pi_0.1.0_all.deb`, run `tidaldrift-pi-setup`, confirm `_ssh`/`_rfb`/`_tidaldrift` in `dns-sd -B` from the Mac
- [ ] TidalDrift shows the Pi with SSH + Screen Share buttons; Screen Sharing connects with the VNC password