### PR TITLE
fix: prefer tigervncpasswd in tidaldrift-pi-setup

### DIFF
--- a/linux/tidaldrift-pi/pkg/DEBIAN/control
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: tidaldrift-pi
-Version: 0.1.0
+Version: 0.1.1
 Section: net
 Priority: optional
 Architecture: all

--- a/linux/tidaldrift-pi/pkg/DEBIAN/postinst
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/postinst
@@ -45,7 +45,7 @@ cat > /etc/avahi/services/tidaldrift-peer.service <<EOF
     <txt-record>peerId=$(xml_escape "$PEER_ID")</txt-record>
     <txt-record>model=$(xml_escape "$MODEL")</txt-record>
     <txt-record>os=$(xml_escape "$OS")</txt-record>
-    <txt-record>version=0.1.0</txt-record>
+    <txt-record>version=0.1.1</txt-record>
     <txt-record>screen=1</txt-record>
     <txt-record>file=0</txt-record>
   </service>

--- a/linux/tidaldrift-pi/pkg/usr/bin/tidaldrift-pi-setup
+++ b/linux/tidaldrift-pi/pkg/usr/bin/tidaldrift-pi-setup
@@ -15,7 +15,13 @@ if [ -z "$USER_NAME" ] || ! id "$USER_NAME" >/dev/null 2>&1; then
 fi
 
 echo "Setting the VNC password for $USER_NAME (used by macOS Screen Sharing)."
-su - "$USER_NAME" -c vncpasswd
+# Prefer the tigervnc-prefixed binary: on systems where RealVNC is also
+# installed, plain vncpasswd resolves to RealVNC's incompatible tool.
+if command -v tigervncpasswd >/dev/null 2>&1; then
+    su - "$USER_NAME" -c tigervncpasswd
+else
+    su - "$USER_NAME" -c vncpasswd
+fi
 
 systemctl enable --now "tidaldrift-vnc@${USER_NAME}.service"
 systemctl reload-or-restart avahi-daemon

--- a/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
+++ b/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
@@ -17,7 +17,7 @@ device list with working SSH and Screen Share buttons.
 ## Install
 
 ```bash
-sudo apt install -y ./tidaldrift-pi_0.1.0_all.deb
+sudo apt install -y ./tidaldrift-pi_0.1.1_all.deb
 sudo tidaldrift-pi-setup <username>
 ```
 


### PR DESCRIPTION
RealVNC's vncpasswd shadows TigerVNC's on stock Raspberry Pi OS and breaks the setup helper; prefer tigervncpasswd when present. Found during the first live install on a Pi running Debian 13. Package version 0.1.1.

Part of #119

## Test plan
- [x] Verified on the Pi: tigervncpasswd -f produced a valid passwd file; service starts and serves RFB 003.008 on port 5900