### PR TITLE
fix: pin tidaldrift-pi VNC SecurityTypes to VncAuth for macOS Screen Sharing

### DIFF
--- a/linux/tidaldrift-pi/pkg/DEBIAN/control
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: tidaldrift-pi
-Version: 0.1.1
+Version: 0.1.2
 Section: net
 Priority: optional
 Architecture: all

--- a/linux/tidaldrift-pi/pkg/DEBIAN/postinst
+++ b/linux/tidaldrift-pi/pkg/DEBIAN/postinst
@@ -45,7 +45,7 @@ cat > /etc/avahi/services/tidaldrift-peer.service <<EOF
     <txt-record>peerId=$(xml_escape "$PEER_ID")</txt-record>
     <txt-record>model=$(xml_escape "$MODEL")</txt-record>
     <txt-record>os=$(xml_escape "$OS")</txt-record>
-    <txt-record>version=0.1.1</txt-record>
+    <txt-record>version=0.1.2</txt-record>
     <txt-record>screen=1</txt-record>
     <txt-record>file=0</txt-record>
   </service>

--- a/linux/tidaldrift-pi/pkg/lib/systemd/system/tidaldrift-vnc@.service
+++ b/linux/tidaldrift-pi/pkg/lib/systemd/system/tidaldrift-vnc@.service
@@ -14,7 +14,11 @@ WorkingDirectory=~
 # display-number port offset. -localhost no exposes it on the LAN; access
 # is gated by the VNC password created by tidaldrift-pi-setup.
 ExecStartPre=/bin/sh -c 'test -s "/home/%i/.config/tigervnc/passwd" || test -s "/home/%i/.vnc/passwd" || { echo "No VNC password set. Run: sudo tidaldrift-pi-setup %i"; exit 1; }'
-ExecStart=/usr/bin/tigervncserver :1 -rfbport 5900 -localhost no -geometry 1920x1080 -depth 24
+# SecurityTypes pinned to VncAuth: TigerVNC's default list (VncAuth,TLSVnc)
+# makes the server advertise VeNCrypt first, and macOS Screen Sharing does
+# not speak VeNCrypt; instead of falling back to VncAuth it aborts with
+# "the software on the remote computer appears to be incompatible".
+ExecStart=/usr/bin/tigervncserver :1 -rfbport 5900 -localhost no -geometry 1920x1080 -depth 24 -SecurityTypes VncAuth
 ExecStop=/usr/bin/tigervncserver -kill :1
 Restart=on-failure
 RestartSec=5

--- a/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
+++ b/linux/tidaldrift-pi/pkg/usr/share/doc/tidaldrift-pi/README.md
@@ -17,7 +17,7 @@ device list with working SSH and Screen Share buttons.
 ## Install
 
 ```bash
-sudo apt install -y ./tidaldrift-pi_0.1.1_all.deb
+sudo apt install -y ./tidaldrift-pi_0.1.2_all.deb
 sudo tidaldrift-pi-setup <username>
 ```
 


### PR DESCRIPTION
macOS Screen Sharing aborts with 'incompatible software' when a server advertises VeNCrypt, which TigerVNC's default SecurityTypes list does. Pin the unit to VncAuth only. Deployed and verified on the live Pi (offer list is now just VncAuth; RFB handshake succeeds). Package 0.1.2.

Part of #119

## Test plan
- [x] RFB security-type offer verified from the Mac: [VncAuth] only
- [ ] User confirms Screen Sharing connects end to end