### PR TITLE
fix: skip no-commit-to-branch in CI, upgrade checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,24 @@ jobs:
     name: Pre-commit
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pre-commit and SwiftLint
         run: brew install pre-commit swiftlint
 
       - name: Run pre-commit hooks
+        # no-commit-to-branch guards *local* commits to main; in CI the
+        # checkout of main after a merge trips it and fails every push run.
+        # CI never commits, so the hook has no value here.
+        env:
+          SKIP: no-commit-to-branch
         run: pre-commit run --all-files
 
   homebrew-cask:
     name: Homebrew Cask
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Style cask
         run: brew style Casks/tidaldrift.rb
@@ -52,7 +57,7 @@ jobs:
     name: SwiftLint
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install SwiftLint
         run: brew install swiftlint
@@ -65,7 +70,7 @@ jobs:
     name: SwiftPM Build and Test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
@@ -82,7 +87,7 @@ jobs:
     name: Xcode Build
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-15
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer


### PR DESCRIPTION
## Summary
- CI pre-commit step sets `SKIP: no-commit-to-branch`: the hook guards local commits to main, but CI's post-merge checkout of main tripped it and failed every push-to-main run (PR runs were green). Local hook behavior is unchanged.
- `actions/checkout` v4 -> v5 in ci.yml and release.yml, clearing the Node.js 20 deprecation annotation.

Closes #126

## Test plan
- [x] PR CI green
- [ ] Post-merge push run on main is green (self-verifying; first green push run since July 2)