### PR TITLE
docs: add Homebrew 6 tap trust step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ TidalDrift replaces the manual workflow of opening System Settings, toggling sha
 
 ### Homebrew (recommended)
 
+Homebrew 6 and later requires trusting a third-party tap before installing
+from it (one-time):
+
 ```bash
+brew trust --tap goldberg-consulting/tap
 brew install --cask goldberg-consulting/tap/tidaldrift
 ```
 


### PR DESCRIPTION
Homebrew 6 blocks installs from untrusted third-party taps; the README's install section predates that. Adds the one-time `brew trust --tap goldberg-consulting/tap` step before the install command.

## Test plan
- [x] Syntax verified against Homebrew 6.0.11 (`brew help trust`; this tap shows Trusted after the command)